### PR TITLE
Upgrade Coverity action

### DIFF
--- a/.github/installCoverity.sh
+++ b/.github/installCoverity.sh
@@ -32,4 +32,4 @@ PATH=$TOOL_DIR/bin:$PATH
 
 cov-configure --template --comptype gcc --compiler gcc-9
 
-echo ::set-env name=PATH::"$PATH"
+echo "PATH=$PATH" >> $GITHUB_ENV

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   scan-linux:
     runs-on: ubuntu-18.04
+    if: github.repository == 'bad-alloc-heavy-industries/substrate'
     strategy:
       fail-fast: false
     steps:
@@ -16,9 +17,8 @@ jobs:
         env:
           WORKSPACE: ${{ github.workspace }}
         run: |
-          echo ::set-env name=PATH::"$HOME/.local/bin:$PATH"
-          echo ::set-env name=GITHUB_WORKSPACE::"`pwd`"
-          echo ::set-env name=COVERITY_PROJECT_NAME::substrate
+          echo "PATH=$HOME/.local/bin:$PATH" >> $GITHUB_ENV
+          echo "GITHUB_WORKSPACE=`pwd`" >> $GITHUB_ENV
       - name: Setup GCC
         shell: bash
         run: |
@@ -26,8 +26,9 @@ jobs:
           sudo apt-add-repository ppa:ubuntu-toolchain-r/test
           sudo apt-get update
           sudo apt-get install $CC $CXX
-          echo ::set-env name=CC::$CC
-          echo ::set-env name=CXX::$CXX
+          echo "CC=$CC" >> $GITHUB_ENV
+          echo "CXX=$CXX" >> $GITHUB_ENV
+          echo "GCOV=${CC/#gcc/gcov}" >> $GITHUB_ENV
         env:
           CC: gcc-9
       - name: Checkout substrate
@@ -38,18 +39,15 @@ jobs:
       - name: Setup Meson + Ninja
         shell: bash
         run: |
-          wget https://github.com/ninja-build/ninja/releases/download/v1.9.0/ninja-linux.zip
           sudo pip3 install --upgrade pip setuptools wheel
-          pip3 install --user meson
-          unzip ninja-linux.zip -d ~/.local/bin
-          rm ninja-linux.zip
+          pip3 install --user meson ninja
         working-directory: ${{ runner.temp }}
       - name: Version tools
         shell: bash
         run: |
           $CC --version
           $CXX --version
-          [ $COVERAGE -ne 0 ] && $GCOV --version || true
+          $GCOV --version
           meson --version
           ninja --version
       - name: Install Coverity
@@ -58,6 +56,7 @@ jobs:
           .github/installCoverity.sh
         env:
           COVERITY_SCAN_TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}
+          COVERITY_PROJECT_NAME: substrate
       - name: Run Coverity
         shell: bash
         run: |


### PR DESCRIPTION
This commit upgrades the Coverity workflow to:

- Use the newer GITHUB_ENV file
- Set a path to gcov
- Use pythonized (and thus automatically updated) ninja
- Only run on the main substrate repo