### PR TITLE
Fix double conversions on socket in Windows

### DIFF
--- a/impl/socket.cxx
+++ b/impl/socket.cxx
@@ -40,7 +40,7 @@ socket_t::~socket_t() noexcept
 bool socket_t::bind(const void *const addr, const size_t len) const noexcept
 	{ return ::bind(socket, static_cast<const sockaddr *>(addr), socklen_t(len)) == 0; }
 bool socket_t::bind(const sockaddr_storage &addr) const noexcept
-	{ return bind(static_cast<const void *>(&addr), socklen_t(sockaddrLen(addr))); }
+	{ return bind(static_cast<const void *>(&addr), sockaddrLen(addr)); }
 bool socket_t::connect(const void *const addr, const size_t len) const noexcept
 	{ return ::connect(socket, static_cast<const sockaddr *>(addr), socklen_t(len)) == 0; }
 bool socket_t::connect(const sockaddr_storage &addr) const noexcept
@@ -63,7 +63,7 @@ ssize_t socket_t::read(void *const bufferPtr, const size_t len) const noexcept
 
 ssize_t socket_t::writeto(void *const bufferPtr, const size_t len, const sockaddr_storage &addr) const noexcept
 {
-	return ::sendto(socket, static_cast<char *>(bufferPtr), len, 0,
+	return ::sendto(socket, static_cast<char *>(bufferPtr), bufferlen_t(len), 0,
 		// NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
 		reinterpret_cast<const sockaddr *>(&addr), socklen_t(sockaddrLen(addr))); // lgtm[cpp/reinterpret-cast]
 }
@@ -71,7 +71,7 @@ ssize_t socket_t::writeto(void *const bufferPtr, const size_t len, const sockadd
 ssize_t socket_t::readfrom(void *const bufferPtr, const size_t len, sockaddr_storage &addr) const noexcept
 {
 	socklen_t size = sizeof(sockaddr_storage);
-	return ::recvfrom(socket, static_cast<char *>(bufferPtr), len, 0,
+	return ::recvfrom(socket, static_cast<char *>(bufferPtr), bufferlen_t(len), 0,
 		// NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
 		reinterpret_cast<sockaddr *>(&addr), &size); // lgtm[cpp/reinterpret-cast]
 }

--- a/substrate/socket
+++ b/substrate/socket
@@ -24,10 +24,12 @@ namespace substrate
 #ifndef _WIN32
 	using socklen_t = unsigned int;
 	using sockType_t = int32_t;
+	using bufferlen_t = size_t; 
 	constexpr static sockType_t INVALID_SOCKET{-1};
 #else
 	using sa_family_t = ADDRESS_FAMILY;
 	using sockType_t = SOCKET;
+	using bufferlen_t = int;
 #endif
 
 	struct socket_t final


### PR DESCRIPTION
👋 

This PR ensures possible type conversions for sockaddr size only occur at usage time. These happen only in Windows, where for some reason winsock2 uses a Qt-style size type.