### PR TITLE
Remove all warnings on MinGW UCRT64

### DIFF
--- a/impl/console.cxx
+++ b/impl/console.cxx
@@ -60,10 +60,10 @@ namespace substrate
 		if (value)
 		{
 #ifdef _WINDOWS
-			const auto consoleMode = setmode(fd, _O_U8TEXT);
-			const size_t valueLen = charTraits::length(value);
-			const size_t stringLen = MultiByteToWideChar(CP_UTF8, MB_PRECOMPOSED | MB_USEGLYPHCHARS,
-				value, int(valueLen), nullptr, 0);
+			const auto consoleMode{setmode(fd, _O_U8TEXT)};
+			const auto valueLen{charTraits::length(value)};
+			const auto stringLen{static_cast<size_t>(MultiByteToWideChar(CP_UTF8, MB_PRECOMPOSED | MB_USEGLYPHCHARS,
+				value, int(valueLen), nullptr, 0))};
 			auto string{make_unique_nothrow<wchar_t []>(stringLen)};
 			if (!string)
 				return;

--- a/substrate/advanced/io
+++ b/substrate/advanced/io
@@ -75,7 +75,7 @@ namespace substrate
 			{
 				std::array<uint8_t, 2> data{};
 				const bool result = read(data);
-				value = (uint16_t(data[1]) << 8U) | data[0];
+				value = uint16_t((uint16_t(data[1]) << 8U) | data[0]);
 				return result;
 			}
 
@@ -115,7 +115,7 @@ namespace substrate
 			{
 				std::array<uint8_t, 2> data{};
 				const bool result = read(data);
-				value = (uint16_t(data[0]) << 8U) | data[1];
+				value = uint16_t((uint16_t(data[0]) << 8U) | data[1]);
 				return result;
 			}
 

--- a/substrate/hash
+++ b/substrate/hash
@@ -160,7 +160,7 @@ namespace substrate
 		}
 		std::uint32_t res = sum % m16 + (sum % m32) / m16;
 
-		return (res % m16) + res / m16;
+		return std::uint16_t((res % m16) + res / m16);
 	}
 
 	template<std::size_t N>
@@ -183,7 +183,7 @@ namespace substrate
 			chksum &= 0xFFFFU;
 		}
 
-		return chksum;
+		return std::uint16_t(chksum);
 	}
 
 	template<std::size_t N>

--- a/substrate/internal/defs
+++ b/substrate/internal/defs
@@ -12,6 +12,15 @@
 #	define __has_cpp_attribute(x) 0
 #endif
 
+// GCC 9 in C++03 mode reports __has_cpp_attribute as true.
+// See
+// https://github.com/boostorg/config/commit/8d58766c7b097ecdf99d414cc08feec313741332
+#if __has_cpp_attribute(no_unique_address) && !(defined(__GNUC__) && (__cplusplus < 201100))
+#	define SUBSTRATE_NO_UNIQUE_ADDRESS(x) [[no_unique_address]] x
+#else
+#	define SUBSTRATE_NO_UNIQUE_ADDRESS(x) x
+#endif
+
 #if __has_cpp_attribute(maybe_unused) || __cplusplus >= 201703L
 #	define SUBSTRATE_NOWARN_UNUSED(x) [[maybe_unused]] x
 #elif defined(__GNUC__)

--- a/substrate/span
+++ b/substrate/span
@@ -124,7 +124,7 @@ namespace substrate
 		constexpr static size_t extent = extent_v;
 
 	private:
-		[[no_unique_address]] internal::extentStorage_t<extent> _extent{0};
+		SUBSTRATE_NO_UNIQUE_ADDRESS(internal::extentStorage_t<extent> _extent{0});
 		pointer _ptr{nullptr};
 
 	public:

--- a/test/utility.cxx
+++ b/test/utility.cxx
@@ -7,6 +7,7 @@
 #if __cplusplus < 201402L && !defined(SUBSTRATE_CXX11_COMPAT)
 #	define SUBSTRATE_CXX11_COMPAT
 #endif
+#include <substrate/internal/defs>
 #include <substrate/utility>
 #include <catch2/catch.hpp>
 
@@ -120,8 +121,8 @@ namespace test
 
 	class Y
 	{
-		int foo; // NOLINT(clang-diagnostic-unused-private-field)
-		double bar; // NOLINT(clang-diagnostic-unused-private-field)
+		SUBSTRATE_NOWARN_UNUSED(int foo);
+		SUBSTRATE_NOWARN_UNUSED(double bar);
 
 	public:
 		Y(int baz) : foo{baz}, bar{} { }
@@ -132,7 +133,7 @@ namespace test
 	{
 		int bar;
 	private:
-		int baz; // NOLINT(clang-diagnostic-unused-private-field)
+		SUBSTRATE_NOWARN_UNUSED(int baz); // NOLINT(clang-diagnostic-unused-private-field)
 	};
 
 	struct AA
@@ -203,8 +204,8 @@ namespace test
 	struct AK
 	{
 	private:
-		int foo;
-		int bar;
+		SUBSTRATE_NOWARN_UNUSED(int foo);
+		SUBSTRATE_NOWARN_UNUSED(int bar);
 	public:
 
 		constexpr AK(std::nullptr_t) noexcept :


### PR DESCRIPTION
👋 

This PR should remove all outstanding warnings on MinGW (and probably on other OSes that use Clang and reasonably modern GCC as well).