### PR TITLE
Add MSVC coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -108,11 +108,79 @@ jobs:
           cd build
           find . -type f -name '*.gcda' -exec $GCOV -p {} + > /dev/null
       - name: Install
+        shell: bash
         run: ninja -C build  install
       - name: Codecov
         if: success()
         uses: codecov/codecov-action@v2
 
+  build-coverage-windows:
+    if: github.repository == 'bad-alloc-heavy-industries/substrate'
+    name: 'build-coverage-windows (${{ matrix.os }}, msvc, ${{ matrix.cpp_std }})'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - windows-2016
+          - windows-2019
+          - windows-2022
+        cpp_std:
+          - 'c++14'
+          - 'c++17'
+      fail-fast: false
+    env:
+      CC: cl.exe
+      CXX: cl.exe
+      LD: link.exe
+    steps:
+      - name: Runtime environment
+        shell: bash
+        env:
+          WORKSPACE: ${{ github.workspace }}
+        run: |
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          echo "GITHUB_WORKSPACE=`pwd`" >> $GITHUB_ENV
+      - name: Setup compiler
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x86_64
+      - name: Setup OpenCppCoverage
+        shell: bash
+        run: |
+          curl -L1O https://github.com/OpenCppCoverage/OpenCppCoverage/releases/download/release-0.9.9.0/OpenCppCoverageSetup-x64-0.9.9.0.exe
+          MSYS2_ARG_CONV_EXCL=/dir=\;/verysilent ./OpenCppCoverageSetup-x64-0.9.9.0 \
+            /dir="C:\Program Files\OpenCppCoverage" /verysilent
+          rm OpenCppCoverageSetup-x64-0.9.9.0.exe
+      - name: Checkout substrate
+        uses: actions/checkout@v2
+        with:
+          lfs: true
+          submodules: true
+      - name: Setup Meson + Ninja
+        shell: bash
+        run: |
+          python3 -m pip install --upgrade pip setuptools wheel
+          python3 -m pip install meson ninja
+        working-directory: ${{ runner.temp }}
+      - name: Version tools
+        shell: bash
+        run: |
+          $CC  || true
+          $LD  || true
+          meson --version
+          ninja --version
+      - name: Configure
+        run: meson build -Db_coverage=true -Dcpp_std=${{ matrix.cpp_std }} $BUILD_OPTS
+      - name: Build
+        run: ninja -C build
+      - name: Test
+        continue-on-error: ${{ startsWith(matrix.os, 'windows-2016') }}
+        run: ninja -C build test
+      - name: Install
+        run: ninja -C build  install
+      - name: Codecov
+        if: success()
+        uses: codecov/codecov-action@v2
   build-coverage-windows-mingw:
     if: github.repository == 'bad-alloc-heavy-industries/substrate'
     name: 'build-coverage-mingw (${{ matrix.os }}, ${{ matrix.sys.abi }}, ${{ matrix.cpp_std }})'

--- a/meson.build
+++ b/meson.build
@@ -13,6 +13,7 @@ project(
 cxx = meson.get_compiler('cpp')
 isWindows = target_machine.system() == 'windows'
 pkgconfig = import('pkgconfig')
+coverage = get_option('b_coverage')
 
 extended_warnings = [
 	'-Wdouble-promotion',
@@ -77,7 +78,7 @@ endif
 
 # Add default defines
 if isWindows
-	add_project_arguments('-DWIN32', '-D_WIN32', '-D_WINDOWS', language: ['c', 'cpp'])
+	add_project_arguments('-DWIN32', '-D_WIN32', '-D_WINDOWS', '-D_CRT_NONSTDC_NO_DEPRECATE', language: ['c', 'cpp'])
 
 	if target_machine.cpu_family() == 'x86_64' or target_machine.cpu_family() == 'aarch64'
 		add_project_arguments('-D_WIN64', language: ['c', 'cpp'])
@@ -87,6 +88,19 @@ if isWindows
 	# Console APIs require Windows 10 17763 (Redstone 5)
 	if cxx.get_id() == 'gcc' or cxx.get_id() == 'clang'
 		add_project_arguments('-DWINVER=NTDDI_WIN10_RS5', '-D_WIN32_WINNT=NTDDI_WIN10_RS5', '-DNTDDI_VERSION=NTDDI_WIN10_RS5', language: ['c', 'cpp'])
+	endif
+
+	if coverage
+		coverageRunner = find_program('OpenCppCoverage', required: false)
+		coverageArgs = [
+			'--sources', '@0@\impl*\*'.format(meson.current_source_dir()),
+			'--sources', '@0@\substrate*\*'.format(meson.current_source_dir()),
+			'--sources', '@0@\test*\*'.format(meson.current_source_dir()),
+			'--sources', '@0@\*'.format(meson.current_build_dir()),
+			'--modules', meson.current_build_dir(),
+			'--export_type'
+		]
+		coverage = coverageRunner.found() and debug
 	endif
 endif
 

--- a/test/meson.build
+++ b/test/meson.build
@@ -40,11 +40,20 @@ tests = executable(
 	install: false,
 )
 
-test(
-	'substrate',
-	tests,
-	workdir: meson.current_build_dir()
-)
+if isWindows and coverage
+	test(
+		'substrate',
+		coverageRunner,
+		args: coverageArgs + ['cobertura:crunch-none-coverage.xml', '--', tests],
+		workdir: meson.current_build_dir()
+	)
+else
+	test(
+		'substrate',
+		tests,
+		workdir: meson.current_build_dir()
+	)
+endif
 
 valgrind = find_program('valgrind', required: false)
 if get_option('valgrind_checks') and valgrind.found()


### PR DESCRIPTION
:wave:

This is a MR to add MSVC's coverage to Codecov. I haven't been able to test it locally because the installer triggers Avast's virus scanner.