### PR TITLE
utility: Mark decode_typename as [[maybe_unused]]

### DIFF
--- a/substrate/utility
+++ b/substrate/utility
@@ -12,6 +12,7 @@
 #include <vector>
 #include <chrono>
 #include <utility>
+#include <substrate/internal/defs>
 #include <substrate/promotion_helpers>
 
 #ifndef _MSC_VER
@@ -532,7 +533,7 @@ namespace substrate
 
 #if !defined(__GNUC__) || defined(__GXX_RTTI)
 	/* typename decoding */
-	static inline std::string decode_typename(const char *const mangled_name)
+	SUBSTRATE_NOWARN_UNUSED(static inline std::string decode_typename(const char *const mangled_name))
 	{
 #ifndef _MSC_VER
 		auto * const demangler = abi::__cxa_demangle(mangled_name, nullptr, nullptr, nullptr);

--- a/substrate/utility
+++ b/substrate/utility
@@ -10,7 +10,6 @@
 #include <string>
 #include <limits>
 #include <vector>
-#include <array>
 #include <chrono>
 #include <utility>
 #include <substrate/promotion_helpers>


### PR DESCRIPTION
👋 

This PR marks `substrate::decode_typename` as `[[maybe_unused]]`, since unused `static inline` functions cause MSVC to emit warning C4505:

```
..\substrate\substrate/utility(536): warning C4505: 'substrate::decode_typename': unreferenced function with internal linkage has been removed
```