### PR TITLE
ci: Re-add missing buildtype for MSVC coverage checks

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -145,6 +145,9 @@ jobs:
         run: |
           echo "$HOME/.local/bin" >> $GITHUB_PATH
           echo "GITHUB_WORKSPACE=`pwd`" >> $GITHUB_ENV
+      - name: Coverage environment
+        run: |
+          echo "BUILD_OPTS=--buildtype=debug" >> $GITHUB_ENV
       - name: Setup compiler
         uses: ilammy/msvc-dev-cmd@v1
         with:


### PR DESCRIPTION
👋 

I just found this mishap on the job upgrade, apologies!