### PR TITLE
Assorted MSVC and CLANG64 fixes

### DIFF
--- a/impl/meson.build
+++ b/impl/meson.build
@@ -12,7 +12,21 @@ else
 endif
 
 if cxx.get_define('__cplusplus').substring(0, -1).version_compare('>=201703')
-	subdir('command_line')
+	std_variant_test = '''
+		#include <variant>
+		#include <vector>
+		int main(int argc, char* argv[])
+		{
+			using tuple_t = std::variant<int, double>;
+			std::vector<tuple_t> list;
+			list.emplace_back(argc - 1);
+
+			return std::get<int>(v.begin());
+		}
+	'''
+	if cxx.compiles(std_variant_test, name: 'has a working std::variant implementation (GCC #90397, LLVM #41863)')
+		subdir('command_line')
+	endif
 endif
 
 libSubstrate = library(

--- a/impl/meson.build
+++ b/impl/meson.build
@@ -11,7 +11,7 @@ else
 	libSubstrateSrcs += 'pty.cxx'
 endif
 
-if get_option('cpp_std').split('++')[1].to_int() >= 17
+if cxx.get_define('__cplusplus').substring(0, -1).version_compare('>=201703')
 	subdir('command_line')
 endif
 

--- a/impl/socket.cxx
+++ b/impl/socket.cxx
@@ -153,8 +153,10 @@ template<size_t offset> inline void *offsetPtr(void *ptr)
 template<size_t offset, typename T, typename U> inline void copyToOffset(T &dest, const U value)
 	{ memcpy(offsetPtr<offset>(&dest), &value, sizeof(U)); }
 
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+#endif
 sockaddr_storage substrate::socket::prepare(const socketType_t family, const char *const where,
 	const uint16_t port, const socketProtocol_t protocol) noexcept
 {
@@ -191,5 +193,7 @@ sockaddr_storage substrate::socket::prepare(const socketType_t family, const cha
 		return {AF_UNSPEC};
 	return service;
 }
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
+#endif
 /* vim: set ft=cpp ts=4 sw=4 noexpandtab: */

--- a/substrate/advanced/fd
+++ b/substrate/advanced/fd
@@ -5,6 +5,11 @@
 #include <substrate/fd>
 #include <substrate/advanced/io>
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4373)
+#endif
+
 namespace substrate
 {
 	namespace advanced
@@ -48,6 +53,10 @@ namespace substrate
 		inline void swap(fd_t &a, fd_t &b) noexcept { a.swap(b); }
 	}
 }
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 #endif /* SUBSTRATE_ADVANCED_FD */
 /* vim: set ft=cpp ts=4 sw=4 noexpandtab: */

--- a/substrate/console
+++ b/substrate/console
@@ -187,7 +187,7 @@ namespace substrate
 		using uint_t = typename std::make_unsigned<int_t>::type;
 		int_t value_;
 
-		[[gnu::noinline]] uint_t format(const consoleStream_t &stream, const uint_t number) const noexcept
+		SUBSTRATE_NOINLINE uint_t format(const consoleStream_t &stream, const uint_t number) const noexcept
 		{
 			if (number < 10)
 				stream.write(char(number + '0'));
@@ -203,7 +203,7 @@ namespace substrate
 			std::is_integral<T>::value && !is_boolean<T>::value && std::is_unsigned<T>::value>
 			printTo(const consoleStream_t &stream) const noexcept { format(stream, value_); }
 
-		template<typename T> [[gnu::noinline]] enable_if_t<std::is_same<T, int_t>::value &&
+		template<typename T> SUBSTRATE_NOINLINE enable_if_t<std::is_same<T, int_t>::value &&
 			std::is_integral<T>::value && !is_boolean<T>::value && std::is_signed<T>::value>
 			printTo(const consoleStream_t &stream) const noexcept
 		{
@@ -250,7 +250,7 @@ namespace substrate
 			constexpr asHex_t(const T value) noexcept : maxDigits{sizeof(T) * 2},
 			msbShift{uint8_t(4U * (maxDigits - 1U))}, _value(value) { }
 
-		[[gnu::noinline]]
+		SUBSTRATE_NOINLINE
 		void operator ()(const consoleStream_t &stream) const noexcept final
 		{
 			uintmax_t value{_value};

--- a/substrate/conversions
+++ b/substrate/conversions
@@ -59,7 +59,7 @@ namespace substrate
 			valueAsInt(const std::chrono::duration<R, P> &number) const noexcept
 				{ return number.count(); }
 
-		[[gnu::noinline]] SUBSTRATE_CXX14_CONSTEXPR arithUint_t process(const arithUint_t number, char *const buffer,
+		SUBSTRATE_NOINLINE SUBSTRATE_CXX14_CONSTEXPR arithUint_t process(const arithUint_t number, char *const buffer,
 			const std::size_t digits, const std::size_t index) const noexcept
 		{
 			if (number < 10)
@@ -83,7 +83,7 @@ namespace substrate
 		template<typename T = int_t> SUBSTRATE_CXX14_CONSTEXPR enable_if_t<std::is_same<T, int_t>::value &&
 			std::is_integral<T>::value && !is_boolean<T>::value && std::is_unsigned<T>::value && _length == npos>
 			format(char *const buffer) const noexcept { process(valueAsInt(_value), buffer); }
-		template<typename T = int_t> [[gnu::noinline]] SUBSTRATE_CXX14_CONSTEXPR
+		template<typename T = int_t> SUBSTRATE_NOINLINE SUBSTRATE_CXX14_CONSTEXPR
 			enable_if_t<std::is_same<T, int_t>::value && std::is_integral<T>::value && !is_boolean<T>::value &&
 			std::is_signed<T>::value && _length == npos> format(char *const buffer) const noexcept
 		{
@@ -115,7 +115,7 @@ namespace substrate
 			std::is_integral<T>::value && !is_boolean<T>::value && std::is_unsigned<T>::value && _length != npos>
 			format(char *const buffer) const noexcept { formatFixed(buffer, valueAsInt(_value)); }
 
-		template<typename T = int_t> [[gnu::noinline]] SUBSTRATE_CXX14_CONSTEXPR
+		template<typename T = int_t> SUBSTRATE_NOINLINE SUBSTRATE_CXX14_CONSTEXPR
 			enable_if_t<std::is_same<T, int_t>::value && std::is_integral<T>::value && !is_boolean<T>::value &&
 			std::is_signed<T>::value && _length != npos> format(char *const buffer) const noexcept
 		{

--- a/substrate/conversions
+++ b/substrate/conversions
@@ -355,16 +355,20 @@ namespace substrate
 
 		SUBSTRATE_NO_DISCARD(SUBSTRATE_CXX14_CONSTEXPR bool isDec() const noexcept)
 		{
-			// NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-			if (_isSigned && _length > 0 && _value[0] == '-' && length() == 1)
-				return false;
+			SUBSTRATE_IF_CONSTEXPR (_isSigned) {
+				// NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+				if(_length > 0 && _value[0] == '-' && length() == 1)
+					return false;
+			}
 			for (size_t i{}; i < _length; ++i)
 			{
+				SUBSTRATE_IF_CONSTEXPR (_isSigned) {
+					// NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+					if(i == 0 && _value[i] == '-')
+						continue;
+				}
 				// NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-				if (_isSigned && i == 0 && _value[i] == '-')
-					continue;
-				// NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-				else if (!isNumber(_value[i]))
+				if (!isNumber(_value[i]))
 					return false;
 			}
 			return true;
@@ -381,16 +385,22 @@ namespace substrate
 			arithUint_t result{};
 			for (size_t i{}; i < _length; ++i)
 			{
-				// NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-				if (_isSigned && i == 0U && _value[i] == '-')
-					continue;
+				SUBSTRATE_IF_CONSTEXPR (_isSigned) {
+					// NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+					if(i == 0U && _value[i] == '-')
+						continue;
+				}
 				result *= 10U;
 				// NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
 				result += arithUint_t(_value[i] - '0');
 			}
-			// NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-			if (_isSigned && _length > 0 && _value[0] == '-')
-				return static_cast<int_t>(-result);
+
+			SUBSTRATE_IF_CONSTEXPR (_isSigned) {
+				// NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+				if (_length > 0 && _value[0] == '-')
+					return static_cast<int_t>(-result);
+			}
+
 			return static_cast<int_t>(result);
 		}
 

--- a/substrate/conversions
+++ b/substrate/conversions
@@ -313,6 +313,13 @@ namespace substrate
 		constexpr inline fromInt_t<value_t, value_t, length, padding>
 			fromInt(const value_t &value) noexcept { return {value}; }
 
+#ifdef _MSC_VER
+#pragma warning(push)
+// (386): warning C4146: unary minus operator applied to unsigned type,
+// result still unsigned
+#pragma warning(disable: 4146)
+#endif
+
 	template<typename int_t> struct toInt_t
 	{
 	private:
@@ -421,6 +428,10 @@ namespace substrate
 			return int_t(result);
 		}
 	};
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 }
 
 #endif /*SUBSTRATE_CONVERSIONS*/

--- a/substrate/crypto/sha256
+++ b/substrate/crypto/sha256
@@ -212,7 +212,7 @@ namespace substrate
 				uint64_t bidx{};
 				std::array<uint32_t, 16> buf{};
 
-				const uint64_t blk_max{len & ~63};
+				const uint64_t blk_max{len & ~63U};
 
 				while (bidx != blk_max) {
 					for (uint8_t i{}; i < 16; ++i) {

--- a/substrate/crypto/sha512
+++ b/substrate/crypto/sha512
@@ -219,7 +219,7 @@ namespace substrate
 				uint64_t bidx{};
 				std::array<uint64_t, 16> buf{};
 
-				const uint64_t blk_max{len & ~127};
+				const uint64_t blk_max{len & ~127U};
 
 				while (bidx != blk_max) {
 					for (uint8_t i{}; i < 16; ++i) {

--- a/substrate/indexed_iterator
+++ b/substrate/indexed_iterator
@@ -54,7 +54,7 @@ namespace substrate
 #endif
 
 	public:
-		constexpr indexedIterator_t(T &container) noexcept : container_{container} { }
+		constexpr indexedIterator_t(T &source) noexcept : container_{source} { }
 
 #if __cplusplus >= 201703L
 		[[nodiscard]] constexpr auto begin() const noexcept

--- a/substrate/internal/defs
+++ b/substrate/internal/defs
@@ -110,6 +110,18 @@
 #	define SUBSTRATE_CXX17_INLINE
 #endif
 
+#if __cplusplus >= 201907L
+#	define SUBSTRATE_CONSTEXPR_STRING constexpr
+#else
+#	define SUBSTRATE_CONSTEXPR_STRING const
+#endif
+
+#if __cplusplus >= 201606L
+#	define SUBSTRATE_IF_CONSTEXPR if constexpr
+#else
+#	define SUBSTRATE_IF_CONSTEXPR if
+#endif
+
 #ifdef _WIN32
 namespace substrate
 {

--- a/substrate/internal/defs
+++ b/substrate/internal/defs
@@ -37,7 +37,7 @@
 #	define SUBSTRATE_NO_DISCARD(...) __VA_ARGS__
 #endif
 
-#if __has_cpp_attribute(fallthrough) || __cplusplus >= 201402L
+#if __has_cpp_attribute(fallthrough) || __cplusplus >= 201603L
 #	define SUBSTRATE_FALLTHROUGH() [[fallthrough]]
 #elif defined(__GNUC__)
 #	define SUBSTRATE_FALLTHROUGH() __attribute__((fallthrough))

--- a/substrate/internal/defs
+++ b/substrate/internal/defs
@@ -45,6 +45,16 @@
 #	define SUBSTRATE_FALLTHROUGH() ((void)0)
 #endif
 
+#if defined(__GNUC__)
+#	define SUBSTRATE_NOINLINE [[gnu::noinline]]
+#elif defined(__clang__)
+#	define SUBSTRATE_NOINLINE [[clang::noinline]]
+#elif defined(_WIN32)
+#	define SUBSTRATE_NOINLINE __declspec(noinline)
+#else
+#	define SUBSTRATE_NOINLINE 
+#endif
+
 #if __cplusplus >= 201103L
 #	define ALIGN(X) alignas(x)
 #elif defined(__GNUC__)

--- a/substrate/internal/defs
+++ b/substrate/internal/defs
@@ -37,7 +37,7 @@
 #	define SUBSTRATE_NO_DISCARD(...) __VA_ARGS__
 #endif
 
-#if __has_cpp_attribute(fallthrough) ||  __cplusplus >= 201402L
+#if __has_cpp_attribute(fallthrough) || __cplusplus >= 201402L
 #	define SUBSTRATE_FALLTHROUGH() [[fallthrough]]
 #elif defined(__GNUC__)
 #	define SUBSTRATE_FALLTHROUGH() __attribute__((fallthrough))

--- a/substrate/iterator
+++ b/substrate/iterator
@@ -8,7 +8,6 @@
 namespace substrate
 {
 	using std::iterator_traits;
-	using std::iterator;
 
 	/**
 	 * Defines an iterator adapter that is 'normal' in the sense that

--- a/substrate/iterator
+++ b/substrate/iterator
@@ -42,8 +42,10 @@ namespace substrate
 
 		reference operator *() const noexcept { return *current; }
 		pointer operator ->() const noexcept { return current; }
-		normalIterator_t operator++(int) noexcept { return normalIterator_t{current++}; }
-		normalIterator_t operator--(int) noexcept { return normalIterator_t{current--}; }
+		// NOLINTNEXTLINE(cert-dcl21-cpp)
+		normalIterator_t operator++(int) noexcept { return {current++}; }
+		// NOLINTNEXTLINE(cert-dcl21-cpp)
+		normalIterator_t operator--(int) noexcept { return {current--}; }
 
 		normalIterator_t &operator ++() noexcept
 		{

--- a/test/advanced/fd.cxx
+++ b/test/advanced/fd.cxx
@@ -11,7 +11,7 @@ using substrate::make_unique;
 
 constexpr static std::array<char, 4> testArray{{'t', 'E', 'S', 't'}};
 constexpr static char testChar{'.'};
-static std::string testString{"fileDescriptor"};
+SUBSTRATE_CONSTEXPR_STRING static std::string testString{"fileDescriptor"};
 
 constexpr static auto u8{uint8_t(0x5A)};
 constexpr static auto i8{int8_t(0xA5)};

--- a/test/advanced/fd.cxx
+++ b/test/advanced/fd.cxx
@@ -14,7 +14,7 @@ constexpr static char testChar{'.'};
 SUBSTRATE_CONSTEXPR_STRING static std::string testString{"fileDescriptor"};
 
 constexpr static auto u8{uint8_t(0x5A)};
-constexpr static auto i8{int8_t(0xA5)};
+constexpr static auto i8{int8_t(0xA5U)};
 constexpr static auto u16{uint16_t(0x125A)};
 constexpr static auto i16{int16_t(0x12A5)};
 constexpr static auto u32{uint32_t(UINT32_C(0x1234565A))};
@@ -102,7 +102,7 @@ TEST_CASE("advanced::fd_t seek", "[advanced::fd_t]")
 	fd_t file{"fd.test", O_RDONLY};
 	REQUIRE(file.valid());
 	REQUIRE(file.tell() == 0);
-	const off_t length = file.length();
+	const auto length = file.length();
 	REQUIRE(length == 78);
 	REQUIRE(file.tail());
 	REQUIRE(file.isEOF());

--- a/test/conversions.cxx
+++ b/test/conversions.cxx
@@ -30,10 +30,14 @@ template<typename int_t> using testFailInt_t = std::vector<int_t>;
 using testFailStr_t = std::vector<const char *>;
 using str_t = std::char_traits<char>;
 
-// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+// NOLINTBEGIN(cppcoreguidelines-macro-usage)
+#define u8(n)		static_cast<uint8_t>(n)
+#define i8(n)		static_cast<int8_t>(n)
+#define u16(n)		static_cast<uint16_t>(n)
+#define i16(n)		static_cast<int16_t>(n)
 #define u64(n)		UINT64_C(n)
-// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define i64(n)		INT64_C(n)
+// NOLINTEND(cppcoreguidelines-macro-usage)
 
 template<typename> constexpr inline size_t typeToOctalLength() noexcept { return static_cast<std::size_t>(-1); }
 template<> constexpr inline size_t typeToOctalLength<uint8_t>() noexcept { return 3; }
@@ -526,13 +530,13 @@ TEST_CASE("Octal conversion to uint8_t", "[conversions]")
 {
 	testToInt_t<uint8_t>::testOctConversions(
 	{
-		{0, ""},
-		{0, "0"},
-		{0, "00"},
-		{0, "000"},
-		{127, "177"},
-		{128, "200"},
-		{255, "377"}
+		{u8(0), ""},
+		{u8(0), "0"},
+		{u8(0), "00"},
+		{u8(0), "000"},
+		{u8(127), "177"},
+		{u8(128), "200"},
+		{u8(255), "377"}
 	});
 }
 
@@ -540,12 +544,12 @@ TEST_CASE("Octal conversion to int8_t", "[conversions]")
 {
 	testToInt_t<int8_t>::testOctConversions(
 	{
-		{0, ""},
-		{0, "000"},
-		{127, "177"},
-		{-1, "377"},
-		{-127, "201"},
-		{-128, "200"}
+		{i8(0), ""},
+		{i8(0), "000"},
+		{i8(127), "177"},
+		{i8(-1), "377"},
+		{i8(-127), "201"},
+		{i8(-128), "200"}
 	});
 }
 
@@ -553,12 +557,12 @@ TEST_CASE("Octal conversion to uint16_t", "[conversions]")
 {
 	testToInt_t<uint16_t>::testOctConversions(
 	{
-		{0, ""},
-		{0, "000000"},
-		{256, "000400"},
-		{32767, "077777"},
-		{32768, "100000"},
-		{65535, "177777"}
+		{u16(0), ""},
+		{u16(0), "000000"},
+		{u16(256), "000400"},
+		{u16(32767), "077777"},
+		{u16(32768), "100000"},
+		{u16(65535), "177777"}
 	});
 }
 
@@ -566,17 +570,17 @@ TEST_CASE("Octal conversion to int16_t", "[conversions]")
 {
 	testToInt_t<int16_t>::testOctConversions(
 	{
-		{0, ""},
-		{0, "000000"},
-		{128, "000200"},
-		{255, "000377"},
-		{256, "000400"},
-		{32767, "077777"},
-		{-1, "177777"},
-		{-255, "177401"},
-		{-256, "177400"},
-		{-32767, "100001"},
-		{-32768, "100000"}
+		{i16(0), ""},
+		{i16(0), "000000"},
+		{i16(128), "000200"},
+		{i16(255), "000377"},
+		{i16(256), "000400"},
+		{i16(32767), "077777"},
+		{i16(-1), "177777"},
+		{i16(-255), "177401"},
+		{i16(-256), "177400"},
+		{i16(-32767), "100001"},
+		{i16(-32768), "100000"}
 	});
 }
 
@@ -584,12 +588,12 @@ TEST_CASE("Octal conversion to uint32_t", "[conversions]")
 {
 	testToInt_t<uint32_t>::testOctConversions(
 	{
-		{0, ""},
-		{0, "00000000000"},
-		{65536, "00000200000"},
-		{2147483647, "17777777777"},
-		{2147483648, "20000000000"},
-		{4294967295, "37777777777"}
+		{0U, ""},
+		{0U, "00000000000"},
+		{65536U, "00000200000"},
+		{2147483647U, "17777777777"},
+		{2147483648U, "20000000000"},
+		{4294967295U, "37777777777"}
 	});
 }
 
@@ -597,17 +601,17 @@ TEST_CASE("Octal conversion to int32_t", "[conversions]")
 {
 	testToInt_t<int32_t>::testOctConversions(
 	{
-		{0, ""},
-		{0, "00000000000"},
-		{32768, "00000100000"},
-		{65535, "00000177777"},
-		{65536, "00000200000"},
-		{2147483647, "17777777777"},
-		{-1, "37777777777"},
-		{-65535, "37777600001"},
-		{-65536, "37777600000"},
-		{-2147483647, "20000000001"},
-		{-2147483648, "20000000000"}
+		{0L, ""},
+		{0L, "00000000000"},
+		{32768L, "00000100000"},
+		{65535L, "00000177777"},
+		{65536L, "00000200000"},
+		{2147483647L, "17777777777"},
+		{-1L, "37777777777"},
+		{-65535L, "37777600001"},
+		{-65536L, "37777600000"},
+		{-2147483647L, "20000000001"},
+		{-2147483648L, "20000000000"}
 	});
 }
 
@@ -626,7 +630,7 @@ TEST_CASE("Octal conversion to uint64_t", "[conversions]")
 	});
 }
 
-TEST_CASE("Octal conversion to int64_t", "[conversions]")
+TEST_CASE("Octal conversion to int64_t", "[conversions] ")
 {
 	testToInt_t<int64_t>::testOctConversions(
 	{
@@ -647,6 +651,7 @@ TEST_CASE("Octal conversion to int64_t", "[conversions]")
 		{i64(-9223372036854775807) - 1, "1000000000000000000000"}
 	});
 }
+
 
 template<typename toInt_t> struct testOctShouldFail_t
 {

--- a/test/fd.cxx
+++ b/test/fd.cxx
@@ -12,7 +12,7 @@ using substrate::make_unique;
 
 constexpr static std::array<char, 4> testArray{{'t', 'E', 'S', 't'}};
 constexpr static char testChar{'.'};
-static std::string testString{"fileDescriptor"};
+SUBSTRATE_CONSTEXPR_STRING static std::string testString{"fileDescriptor"};
 
 constexpr static auto u8{uint8_t(0x5A)};
 constexpr static auto i8{int8_t(0xA5)};

--- a/test/fd.cxx
+++ b/test/fd.cxx
@@ -15,7 +15,7 @@ constexpr static char testChar{'.'};
 SUBSTRATE_CONSTEXPR_STRING static std::string testString{"fileDescriptor"};
 
 constexpr static auto u8{uint8_t(0x5A)};
-constexpr static auto i8{int8_t(0xA5)};
+constexpr static auto i8{int8_t(0xA5U)};
 constexpr static auto u16{uint16_t(0x125A)};
 constexpr static auto i16{int16_t(0x12A5)};
 constexpr static auto u32{uint32_t(UINT32_C(0x1234565A))};
@@ -103,7 +103,7 @@ TEST_CASE("fd_t seek", "[fd_t]")
 	fd_t file{"fd.test", O_RDONLY};
 	REQUIRE(file.valid());
 	REQUIRE(file.tell() == 0);
-	const off_t length = file.length();
+	const auto length = file.length();
 	REQUIRE(length == 78);
 	REQUIRE(file.tail());
 	REQUIRE(file.isEOF());


### PR DESCRIPTION
Hey @dragonmux,

As promised, here are some fixes for last night's Substrate woes. On the MSVC side of things, I fixed all warnings except:

```
C:\Users\Amalia\Desktop\Rachel\substrate\substrate/console(87): warning C4251: 'substrate::console_t::consoleMutex': class 'std::mutex' needs to have dll-interface to be used by clients of struct 'substrate::console_t'
```

Additionally I fixed your C++ standard check, as, in old AppleClang versions, Meson can downgrade standard under your back and this would go undetected. I also took care of the CI fails regarding `command_line` due to old libstdc++ having an improper definition of `std::variant` internals.