### PR TITLE
command_line: Fix working <variant> check

### DIFF
--- a/impl/meson.build
+++ b/impl/meson.build
@@ -13,18 +13,28 @@ endif
 
 if cxx.get_define('__cplusplus').substring(0, -1).version_compare('>=201703')
 	std_variant_test = '''
-		#include <variant>
-		#include <vector>
-		int main(int argc, char* argv[])
+		template <typename U>
+		auto foo(U u)
 		{
-			using tuple_t = std::variant<int, double>;
-			std::vector<tuple_t> list;
-			list.emplace_back(argc - 1);
+			u.v;
+		}
 
-			return std::get<int>(v.begin());
+		template <typename T>
+		class X
+		{
+			T v;
+
+		public:
+			template <typename U>
+			friend auto foo(U);
+		};
+
+		int main()
+		{
+			::foo(X<int>{});
 		}
 	'''
-	if cxx.compiles(std_variant_test, name: 'has a working std::variant implementation (GCC #90397, LLVM #41863)')
+	if cxx.compiles(std_variant_test, name: 'has a working std::variant implementation (LLVM #31852, #33222)')
 		subdir('command_line')
 	endif
 endif


### PR DESCRIPTION
👋 

This PR is to fix the wrong variant check you'd told me about last night.

The previous attempt instead banned all compilers due to a typo. After fixing it and having it pass in affected compiler, bisecting [1] revealed I'd run into a different but associated Clang bug [2] [3].

[1]: https://gcc.gnu.org/git/?p=gcc.git;a=history;f=libstdc%2B%2B-v3/include/std/variant;h=35781495e3117ed22ab6fa1745fd0ea2cfc66308;hb=HEAD
[2]: https://bugs.llvm.org/show_bug.cgi?id=31852
[3]: https://bugs.llvm.org/show_bug.cgi?id=33222