### PR TITLE
Naughty & Nice pointers

### DIFF
--- a/substrate/pointer_utils
+++ b/substrate/pointer_utils
@@ -97,4 +97,42 @@ SUBSTRATE_DEDUCTION_GUIDE(
 } // namespace substrate
 
 #endif
+
+namespace substrate
+{
+	template<typename ValueType, typename ReturnType, ReturnType (*Deleter)(ValueType *)>
+		struct naughtyPtr_t : public std::shared_ptr<ValueType>
+	{
+	private:
+		static void deleter(ValueType* value)
+		{
+			if (value != nullptr)
+				Deleter(value);
+		}
+
+	public:
+		naughtyPtr_t() : std::shared_ptr<ValueType>{nullptr, deleter} { }
+
+		template<typename... Args> naughtyPtr_t(Args &&...args) :
+			std::shared_ptr<ValueType>{std::forward<Args>(args)..., deleter} { }
+	};
+
+	template<typename> struct deleter_type;
+	template<typename R, typename T> struct deleter_type<R(T *)>
+	{
+		using value_type = T;
+		using return_type = R;
+	};
+
+	template<typename T, T t, typename D = deleter_type<T>>
+	struct nicePtr_t : public naughtyPtr_t<typename D::value_type, 
+		typename D::return_type, t>
+	{
+	public:
+		nicePtr_t() = default;
+		template<typename... Args> nicePtr_t(Args &&...args) :
+			naughtyPtr_t<typename D::value_type, typename D::return_type, t>{std::forward<Args>(args)...} { }
+	};
+} // namespace substrate
+
 #endif

--- a/substrate/pointer_utils
+++ b/substrate/pointer_utils
@@ -118,7 +118,7 @@ namespace substrate
 	};
 
 	template<typename> struct deleter_type;
-	template<typename R, typename T> struct deleter_type<R(T *)>
+	template<typename R, typename T> struct deleter_type<R(*)(T *)>
 	{
 		using value_type = T;
 		using return_type = R;

--- a/test/pointer_utils.cxx
+++ b/test/pointer_utils.cxx
@@ -116,7 +116,7 @@ TEST_CASE("naughty (non-void-returning) deleter", "[naughtyPtr_t]")
 
 TEST_CASE("nice (void-returning) deleter", "[nicePtr_t]")
 {
-	using nicePtr = substrate::nicePtr_t<decltype(releaseFloat), &releaseFloat>;
+	using nicePtr = substrate::nicePtr_t<decltype(&releaseFloat), &releaseFloat>;
 
 	nicePtr sample{new float(2.0F)};
 

--- a/test/pointer_utils.cxx
+++ b/test/pointer_utils.cxx
@@ -87,3 +87,40 @@ TEST_CASE("managed release check through convertible values", "[managedTupleWith
 }
 
 #endif
+
+static int releaseInt(int *value)
+{
+	REQUIRE(value != nullptr);
+	REQUIRE(*value == 1);
+	delete value; // NOLINT(*-owning-memory)
+	return 1;
+};
+
+static void releaseFloat(float *value)
+{
+	REQUIRE(value != nullptr);
+	REQUIRE(*value == 2.0F);
+	delete value; // NOLINT(*-owning-memory)
+};
+
+TEST_CASE("naughty (non-void-returning) deleter", "[naughtyPtr_t]")
+{
+	using naughtyPtr = substrate::naughtyPtr_t<int, int, releaseInt>;
+
+	naughtyPtr sample{new int(1)};
+
+	REQUIRE(*sample == 1);
+	sample.reset();
+	REQUIRE(sample.use_count() == 0);
+}
+
+TEST_CASE("nice (void-returning) deleter", "[nicePtr_t]")
+{
+	using nicePtr = substrate::nicePtr_t<decltype(releaseFloat), &releaseFloat>;
+
+	nicePtr sample{new float(2.0F)};
+
+	REQUIRE(*sample == 2.0F);
+	sample.reset();
+	REQUIRE(sample.use_count() == 0);
+}


### PR DESCRIPTION
Hi!

This MR proposes adding a neat pattern for automagically dealing with naughty (non-void returning) and nice (void-returning) C-style deleter functions.

Conceptually, they're the same as constructing `std::shared_ptr<T, Deleter>`, only that they allow:

- passing the deleter at compile time (excellent for creating many such complex pointers with a single `using`)
- using said pointers with misbehaving libraries (eg. Fontconfig, which [crashes when faced with a null pointer](https://gitlab.freedesktop.org/fontconfig/fontconfig/-/issues/339)).