### PR TITLE
Officially add C++20 support

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,6 +23,9 @@ jobs:
           - 'clang-10'
           - 'clang-11'
           - 'clang-12'
+          - 'clang-13'
+          - 'clang-14'
+          - 'clang-15'
           - 'gcc-7'
           - 'gcc-8'
           - 'gcc-9'
@@ -32,6 +35,11 @@ jobs:
           - 'c++11'
           - 'c++14'
           - 'c++17'
+        include:
+          - compiler: 'clang-15'
+            cpp_std: 'c++20'
+          - compiler: 'gcc-11'
+            cpp_std: 'c++20'
       fail-fast: false
     steps:
       - name: Runtime environment
@@ -64,15 +72,23 @@ jobs:
           wget https://apt.llvm.org/llvm-snapshot.gpg.key
           sudo apt-key add llvm-snapshot.gpg.key
           rm llvm-snapshot.gpg.key
-          sudo apt-add-repository "deb https://apt.llvm.org/focal/ llvm-toolchain-focal main"
+          sudo apt-add-repository "deb https://apt.llvm.org/focal/ llvm-toolchain-focal${CC/#clang/} main"
           sudo apt-get update
+          sudo apt-get install $CC gcovr
           CXX=${CC/#clang/clang++}
-          sudo apt-get install $CC $CXX gcovr
           echo "CC=$CC" >> $GITHUB_ENV
           echo "CXX=$CXX" >> $GITHUB_ENV
           echo "GCOV=/usr/lib/${CC/#clang/llvm}/bin/llvm-cov gcov" >> $GITHUB_ENV
         env:
           CC: ${{ matrix.compiler }}
+        working-directory: ${{ runner.temp }}
+      - name: Add coverage dependency
+        if: matrix.compiler == 'clang-14'
+        shell: bash
+        run: |
+          apt download libclang-rt-14-dev
+          PACKAGE=$(find . -name 'libclang-rt-14*.deb')
+          sudo dpkg --install --force-breaks $PACKAGE
         working-directory: ${{ runner.temp }}
       - name: Checkout
         uses: actions/checkout@v3
@@ -207,6 +223,9 @@ jobs:
           - 'c++11'
           - 'c++14'
           - 'c++17'
+        include:
+          - os: windows-2022
+            cpp_std: 'c++20'
       fail-fast: false
     steps:
       - name: Use MinGW from MSYS
@@ -361,6 +380,9 @@ jobs:
           - 'c++11'
           - 'c++14'
           - 'c++17'
+        include:
+          - compiler: gcc
+            cpp_std: 'c++20'
       fail-fast: false
     steps:
       - name: Runtime environment

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   build-coverage-linux:
     if: github.repository == 'bad-alloc-heavy-industries/substrate'
-    runs-on: ubuntu-20.04
+    runs-on: ${{ matrix.os.id }}
     strategy:
       matrix:
+        os:
+          - { id: ubuntu-20.04, name: focal }
         compiler:
           - 'clang-9'
           - 'clang-10'
@@ -36,9 +38,11 @@ jobs:
           - 'c++14'
           - 'c++17'
         include:
-          - compiler: 'clang-15'
+          - os: { id: ubuntu-20.04, name: focal }
+            compiler: 'clang-15'
             cpp_std: 'c++20'
-          - compiler: 'gcc-11'
+          - os: { id: ubuntu-20.04, name: focal }
+            compiler: 'gcc-11'
             cpp_std: 'c++20'
       fail-fast: false
     steps:
@@ -72,7 +76,7 @@ jobs:
           wget https://apt.llvm.org/llvm-snapshot.gpg.key
           sudo apt-key add llvm-snapshot.gpg.key
           rm llvm-snapshot.gpg.key
-          sudo apt-add-repository "deb https://apt.llvm.org/focal/ llvm-toolchain-focal${CC/#clang/} main"
+          sudo apt-add-repository "deb https://apt.llvm.org/${{ matrix.os.name }}/ llvm-toolchain-${{ matrix.os.name }}${CC/#clang/} main"
           sudo apt-get update
           sudo apt-get install $CC gcovr
           CXX=${CC/#clang/clang++}

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -24,6 +24,9 @@ jobs:
           - 'clang-10'
           - 'clang-11'
           - 'clang-12'
+          - 'clang-13'
+          - 'clang-14'
+          - 'clang-15'
           - 'gcc-7'
           - 'gcc-8'
           - 'gcc-9'
@@ -61,6 +64,12 @@ jobs:
           - os: { id: ubuntu-18.04, name: bionic }
             compiler: 'clang-8'
             cpp_std: 'c++17'
+          - os: { id: ubuntu-20.04, name: focal }
+            compiler: 'clang-15'
+            cpp_std: 'c++20'
+          - os: { id: ubuntu-20.04, name: focal }
+            compiler: 'gcc-11'
+            cpp_std: 'c++20'
           ## GCC6 cannot handle constexpr-ness of mmap_t
           ## See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66297
           # - os: { id: ubuntu-18.04, name: bionic }
@@ -100,10 +109,10 @@ jobs:
           wget https://apt.llvm.org/llvm-snapshot.gpg.key
           sudo apt-key add llvm-snapshot.gpg.key
           rm llvm-snapshot.gpg.key
-          sudo apt-add-repository "deb https://apt.llvm.org/${{ matrix.os.name }}/ llvm-toolchain-${{ matrix.os.name }} main"
+          sudo apt-add-repository "deb https://apt.llvm.org/${{ matrix.os.name }}/ llvm-toolchain-${{ matrix.os.name }}${CC/#clang/} main"
           sudo apt-get update
+          sudo apt-get install $CC
           CXX=${CC/#clang/clang++}
-          sudo apt-get install $CC $CXX
           echo "CC=$CC" >> $GITHUB_ENV
           echo "CXX=$CXX" >> $GITHUB_ENV
         env:
@@ -146,6 +155,9 @@ jobs:
         cpp_std:
           - 'c++14'
           - 'c++17'
+        include:
+          - os: windows-2022
+            cpp_std: 'c++20'
       fail-fast: false
     env:
       CC: cl.exe
@@ -207,6 +219,7 @@ jobs:
           - 'c++11'
           - 'c++14'
           - 'c++17'
+          - 'c++20'
       fail-fast: false
     steps:
       - name: Use MinGW from MSYS
@@ -331,6 +344,9 @@ jobs:
           - 'c++11'
           - 'c++14'
           - 'c++17'
+        include:
+          - compiler: gcc
+            cpp_std: 'c++20'
       fail-fast: false
     steps:
       - name: Runtime environment

--- a/README.md
+++ b/README.md
@@ -209,7 +209,6 @@
             <th>mingw64</th>
             <th>ucrt64</th>
             <th>clang64</th>
-            <th>15.9</th>
             <th>16.11</th>
             <th>17.0</th>
         </tr>
@@ -221,7 +220,7 @@
         <td>:heavy_check_mark:</td>
         <td>:heavy_check_mark:</td>
         <td>:heavy_check_mark:</td>
-        <td colspan="3" style="text-align:center;">N/A</td>
+        <td colspan="2" style="text-align:center;">N/A</td>
       </tr>
       <tr>
         <td>C++ 14</td>
@@ -230,11 +229,9 @@
         <td>:heavy_check_mark:</td>
         <td>:heavy_check_mark:</td>
         <td>:heavy_check_mark:</td>
-        <td>:heavy_check_mark:</td>
       </tr>
       <tr>
         <td>C++ 17</td>
-        <td>:heavy_check_mark:</td>
         <td>:heavy_check_mark:</td>
         <td>:heavy_check_mark:</td>
         <td>:heavy_check_mark:</td>

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
         </tr>
         <tr>
             <th colspan="5" style="border-right: 1px solid !important;">G++</th>
-            <th colspan="8" style="border-right: 1px solid !important;">Clang</th>
+            <th colspan="11" style="border-right: 1px solid !important;">Clang</th>
         </tr>
         <tr>
             <th>7</th>
@@ -31,12 +31,18 @@
             <th>10</th>
             <th>11</th>
             <th>12</th>
+            <th>13</th>
+            <th>14</th>
+            <th>15</th>
         </tr>
     </thead>
     <tbody>
       <tr>
-        <td rowspan="3">Linux</td>
+        <td rowspan="4">Linux</td>
         <td>C++ 11</td>
+        <td>:heavy_check_mark:</td>
+        <td>:heavy_check_mark:</td>
+        <td>:heavy_check_mark:</td>
         <td>:heavy_check_mark:</td>
         <td>:heavy_check_mark:</td>
         <td>:heavy_check_mark:</td>
@@ -66,6 +72,9 @@
         <td>:heavy_check_mark:</td>
         <td>:heavy_check_mark:</td>
         <td>:heavy_check_mark:</td>
+        <td>:heavy_check_mark:</td>
+        <td>:heavy_check_mark:</td>
+        <td>:heavy_check_mark:</td>
       </tr>
       <tr>
         <td>C++ 17</td>
@@ -81,6 +90,28 @@
         <td>:heavy_check_mark:</td>
         <td>:heavy_check_mark:</td>
         <td>:heavy_check_mark:</td>
+        <td>:heavy_check_mark:</td>
+        <td>:heavy_check_mark:</td>
+        <td>:heavy_check_mark:</td>
+        <td>:heavy_check_mark:</td>
+      </tr>
+      <tr>
+        <td>C++ 20</td>
+        <td>:x:</td>
+        <td>:x:</td>
+        <td>:x:</td>
+        <td>:x:</td>
+        <td>:heavy_check_mark:</td>
+        <td>:x:</td>
+        <td>:x:</td>
+        <td>:x:</td>
+        <td>:x:</td>
+        <td>:x:</td>
+        <td>:x:</td>
+        <td>:x:</td>
+        <td>:x:</td>
+        <td>:x:</td>
+        <td>:x:</td>
         <td>:heavy_check_mark:</td>
       </tr>
       <tr>
@@ -158,7 +189,7 @@
     </thead>
     <tbody>
       <tr>
-       <td rowspan="3">macOS</td>
+       <td rowspan="4">macOS</td>
         <td>C++ 11</td>
         <td>:heavy_check_mark: (1)</td>
         <td>:heavy_check_mark: (1)</td>
@@ -187,6 +218,16 @@
         <td>:heavy_check_mark:</td>
         <td>:heavy_check_mark:</td>
         <td>:heavy_check_mark:</td>
+      </tr>
+      <tr>
+        <td>C++ 20</td>
+        <td>:x:</td>
+        <td>:x:</td>
+        <td>:x:</td>
+        <td>:x:</td>
+        <td>:heavy_check_mark:</td>
+        <td>:x:</td>
+        <td>:x:</td>
       </tr>
     </tbody>
 </table>
@@ -215,7 +256,7 @@
     </thead>
     <tbody>
       <tr>
-       <td rowspan="3">Windows</td>
+       <td rowspan="4">Windows</td>
         <td>C++ 11</td>
         <td>:heavy_check_mark:</td>
         <td>:heavy_check_mark:</td>
@@ -236,6 +277,14 @@
         <td>:heavy_check_mark:</td>
         <td>:heavy_check_mark:</td>
         <td>:heavy_check_mark:</td>
+        <td>:heavy_check_mark:</td>
+      </tr>
+      <tr>
+        <td>C++ 20</td>
+        <td>:heavy_check_mark:</td>
+        <td>:heavy_check_mark:</td>
+        <td>:heavy_check_mark:</td>
+        <td>:x:</td>
         <td>:heavy_check_mark:</td>
       </tr>
     </tbody>

--- a/substrate/internal/defs
+++ b/substrate/internal/defs
@@ -110,12 +110,6 @@
 #	define SUBSTRATE_CXX17_INLINE
 #endif
 
-#if __cplusplus >= 201907L
-#	define SUBSTRATE_CONSTEXPR_STRING constexpr
-#else
-#	define SUBSTRATE_CONSTEXPR_STRING const
-#endif
-
 #if __cplusplus >= 201606L
 #	define SUBSTRATE_IF_CONSTEXPR if constexpr
 #else

--- a/substrate/utility
+++ b/substrate/utility
@@ -308,8 +308,10 @@ namespace substrate
 	template<class T>
 	constexpr inline bool is_const_v = std::is_const_v<T>;
 
+#if __cplusplus < 202002L
 	template<class T>
 	constexpr inline bool is_literal_type_v = std::is_literal_type_v<T>;
+#endif
 
 	template<class T>
 	constexpr inline bool is_final_v = std::is_final_v<T>;

--- a/test/advanced/fd.cxx
+++ b/test/advanced/fd.cxx
@@ -11,7 +11,7 @@ using substrate::make_unique;
 
 constexpr static std::array<char, 4> testArray{{'t', 'E', 'S', 't'}};
 constexpr static char testChar{'.'};
-SUBSTRATE_CONSTEXPR_STRING static std::string testString{"fileDescriptor"};
+const static std::string testString{"fileDescriptor"};
 
 constexpr static auto u8{uint8_t(0x5A)};
 constexpr static auto i8{int8_t(0xA5U)};

--- a/test/fd.cxx
+++ b/test/fd.cxx
@@ -12,7 +12,7 @@ using substrate::make_unique;
 
 constexpr static std::array<char, 4> testArray{{'t', 'E', 'S', 't'}};
 constexpr static char testChar{'.'};
-SUBSTRATE_CONSTEXPR_STRING static std::string testString{"fileDescriptor"};
+const static std::string testString{"fileDescriptor"};
 
 constexpr static auto u8{uint8_t(0x5A)};
 constexpr static auto i8{int8_t(0xA5U)};


### PR DESCRIPTION
👋 

This MR ensures C++20 is properly supported (apologies for the mishap with constexpr std::string!) and documents it.

For future reference, I've also added CI jobs and fixed the LLVM deployment. Turns out, apt.llvm.org no longer includes multiple versions in the tip toolchain, only the latest. Moreover, `clang++-xy` is only a package that exists in Ubuntu (trying to install it when targeting Clang 13+ ends up with an error).