### PR TITLE
fd: Fix misallowed usage of std::filesystem::path for Apple

### DIFF
--- a/substrate/fd
+++ b/substrate/fd
@@ -10,9 +10,6 @@
 #include <string>
 #if __cplusplus >= 201703L
 #include <string_view>
-#if __has_include(<filesystem>)
-#include <filesystem>
-#endif
 #endif
 
 #include <substrate/internal/defs>
@@ -23,6 +20,10 @@
 
 #ifndef _WINDOWS
 #	include <substrate/mmap>
+#endif
+
+#if defined(SUBSTRATE_ALLOW_STD_FILESYSTEM_PATH)
+#include <filesystem>
 #endif
 
 namespace substrate
@@ -49,10 +50,10 @@ namespace substrate
 #if __cplusplus >= 201703L
 		fd_t(const std::string_view &fileName, const int flags, const mode_t mode = 0) noexcept :
 			fd{internal::fdopen(fileName.data(), flags, mode)} { }
-#if __has_include(<filesystem>)
+#endif
+#if defined(SUBSTRATE_ALLOW_STD_FILESYSTEM_PATH)
 		fd_t(const std::filesystem::path &fileName, const int flags, const mode_t mode = 0) noexcept :
 			fd{internal::fdopen(fileName.c_str(), flags, mode)} { }
-#endif
 #endif
 		fd_t(fd_t &&fd_) noexcept : fd_t{} { swap(fd_); }
 		~fd_t() noexcept { if (fd != -1) close(fd); }

--- a/substrate/internal/defs
+++ b/substrate/internal/defs
@@ -127,5 +127,17 @@ namespace substrate
 }
 #endif
 
+#if __cplusplus >= 201703L || (defined(__cpp_lib_filesystem) && __cpp_lib_filesystem >= 201703L)
+#	if !defined(__APPLE__)
+#		define SUBSTRATE_ALLOW_STD_FILESYSTEM_PATH 1
+#	else
+#		include <Availability.h>
+#		include <TargetConditionals.h>
+#		if (TARGET_OS_OSX && __MAC_OS_X_VERSION_MIN_REQUIRED >= 101500L) || (TARGET_OS_IOS && __IPHONE_OS_VERSION_MIN_REQUIRED >= 130000L) || (TARGET_OS_WATCH && __WATCH_OS_VERSION_MIN_REQUIRED >= 60000L) || (TARGET_OS_TV && __TV_OS_VERSION_MIN_REQUIRED >= 130000L)
+#			define SUBSTRATE_ALLOW_STD_FILESYSTEM_PATH 1
+#		endif
+#	endif
+#endif
+
 #endif /* SUBSTRATE_INTERNAL_DEFS */
 /* vim: set ft=cpp ts=4 sw=4 noexpandtab: */


### PR DESCRIPTION
`std::filesystem` APIs are only available starting with macOS 10.15, iOS and tvOS 13.0, and watchOS 6.0. `__cplusplus` or `__cpp_lib_filesystem` values are not enough for checking this.

<img width="848" alt="Captura de Pantalla 2023-03-19 a la(s) 09 58 14" src="https://user-images.githubusercontent.com/13498015/226176714-415a5b7a-0fc5-45a0-a405-51dfb39a22f8.png">
