### PR TITLE
rwlock (and bswap8 because oops)

### DIFF
--- a/substrate/bits
+++ b/substrate/bits
@@ -11,6 +11,14 @@
 namespace substrate
 {
 	/* endian swapping facilities */
+	SUBSTRATE_NO_DISCARD(inline constexpr uint8_t swap8(const uint8_t x) noexcept)
+	{
+		return uint8_t(
+			((x & 0x0FU) << 4U) |
+			((x & 0xF0U) >> 4U)
+		);
+	}
+
 	SUBSTRATE_NO_DISCARD(inline constexpr uint16_t swap16(const uint16_t x) noexcept)
 	{
 		return uint16_t(

--- a/substrate/rwlock
+++ b/substrate/rwlock
@@ -15,33 +15,39 @@
 namespace substrate
 {
 	template<typename T>
-	struct rwlock final {
+	struct rwlock_t final
+	{
 	private:
 		template<typename U, template<typename> typename lock_t>
-		struct lock_result final {
+		struct lockResult_t final
+		{
 		private:
 			lock_t<std::shared_mutex> _lock;
-			U& _obj;
+			U &_obj;
+
 		public:
-			constexpr lock_result(std::shared_mutex& mut, U& obj) noexcept :
+			constexpr lockResult_t(std::shared_mutex &mut, U &obj) noexcept :
 				_lock{mut}, _obj{obj} { }
 
-			SUBSTRATE_NO_DISCARD(U* operator->() noexcept { return &_obj; })
-			SUBSTRATE_NO_DISCARD(U& operator*() noexcept { return _obj; })
+			SUBSTRATE_NO_DISCARD(U *operator ->() noexcept) { return &_obj; }
+			SUBSTRATE_NO_DISCARD(U &operator *() noexcept) { return _obj; }
 		};
 		std::shared_mutex _mutex{};
 		T _obj;
+
 	public:
 		template<typename ...args_t>
-		constexpr rwlock(args_t&&... args) noexcept :
+		constexpr rwlock_t(args_t &&...args) noexcept :
 			_obj{std::forward<args_t>(args)...} { }
 
-		SUBSTRATE_NO_DISCARD(lock_result<const T, std::shared_lock> read() noexcept {
+		SUBSTRATE_NO_DISCARD(lockResult_t<const T, std::shared_lock> read() noexcept)
+		{
 			return {_mutex, _obj};
-		})
-		SUBSTRATE_NO_DISCARD(lock_result<T, std::unique_lock> write() noexcept {
+		}
+		SUBSTRATE_NO_DISCARD(lockResult_t<T, std::unique_lock> write() noexcept)
+		{
 			return {_mutex, _obj};
-		})
+		}
 	};
 }
 

--- a/substrate/rwlock
+++ b/substrate/rwlock
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: BSD-3-Clause
+#ifndef SUBSTRATE_RWLOCK
+#define SUBSTRATE_RWLOCK
+
+#if __cplusplus < 201703L
+#error "rwlock is on available on C++17 and above"
+#endif
+
+#include <substrate/internal/defs>
+
+#include <utility>
+#include <mutex>
+#include <shared_mutex>
+
+namespace substrate
+{
+	template<typename T>
+	struct rwlock final {
+	private:
+		template<typename U, template<typename> typename lock_t>
+		struct lock_result final {
+		private:
+			lock_t<std::shared_mutex> _lock;
+			U& _obj;
+		public:
+			constexpr lock_result(std::shared_mutex& mut, U& obj) noexcept :
+				_lock{mut}, _obj{obj} { }
+
+			SUBSTRATE_NO_DISCARD(U* operator->() noexcept { return &_obj; })
+			SUBSTRATE_NO_DISCARD(U& operator*() noexcept { return _obj; })
+		};
+		std::shared_mutex _mutex{};
+		T _obj;
+	public:
+		template<typename ...args_t>
+		constexpr rwlock(args_t&&... args) noexcept :
+			_obj{std::forward<args_t>(args)...} { }
+
+		SUBSTRATE_NO_DISCARD(lock_result<const T, std::shared_lock> read() noexcept {
+			return {_mutex, _obj};
+		})
+		SUBSTRATE_NO_DISCARD(lock_result<T, std::unique_lock> write() noexcept {
+			return {_mutex, _obj};
+		})
+	};
+}
+
+#endif /* SUBSTRATE_RWLOCK */
+/* vim: set ft=cpp ts=4 sw=4 noexpandtab: */

--- a/test/bits.cxx
+++ b/test/bits.cxx
@@ -44,11 +44,20 @@ TEST_CASE("shift nibble", "[bits]")
 	REQUIRE(shift_nibble<decltype(value2)>(value2, 16U) == 0x0123456789ABCDEFLLU);
 }
 
+using substrate::swap8;
 using substrate::swap16;
 using substrate::swap32;
 using substrate::swap64;
 TEST_CASE("bswap tests", "[bits]")
 {
+	SECTION("bswap8")
+	{
+		REQUIRE(swap8(0x34U) == 0x43U);
+		REQUIRE(swap8(0x12U) == 0x21U);
+		REQUIRE(swap8(0x24U) == 0x42U);
+		REQUIRE(swap8(0x23U) == 0x32U);
+	}
+
 	SECTION("bswap16")
 	{
 		REQUIRE(swap16(0x3412U) == 0x1234U);


### PR DESCRIPTION
This is just an initial draft of `rwlock` for #18, as it uses `std::shared_mutex` it's exclusive to C++17 or newer.