### PR TITLE
ci: Fix dragonmux's clang-format file and allow a minimal fallback style

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,4 +1,5 @@
 ---
+BasedOnStyle: WebKit
 AccessModifierOffset: -4
 AlignAfterOpenBracket: DontAlign
 AlignConsecutiveAssignments: false
@@ -100,7 +101,7 @@ SpacesInCStyleCastParentheses: false
 SpacesInContainerLiterals: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
-Standard: Cpp11
+Standard: Latest
 StatementMacros: null
 TabWidth: 4
 UseTab: Always


### PR DESCRIPTION
Hi @dragonmux,

Here's the PR bringing your .clang-format file back. It obviously doesn't cover all your style quirks, but it will now be happily accepted by clangd 😄 