### PR TITLE
Add a container zipper class

### DIFF
--- a/substrate/span
+++ b/substrate/span
@@ -29,10 +29,6 @@ namespace substrate
 	template<typename C> constexpr auto data(const C &c) -> decltype(c.data()) { return c.data(); }
 	template<typename T, std::size_t N> constexpr T *data(T (&array)[N]) noexcept { return array; }
 	template<typename E> constexpr const E *data(std::initializer_list<E> il) noexcept { return il.data(); }
-	template<typename C> constexpr auto size(const C &c) -> decltype(c.size()) { return c.size(); }
-	template<typename T, std::size_t N> constexpr std::size_t size(const T (&)[N]) noexcept { return N; }
-	template<typename T, std::size_t N> constexpr std::ptrdiff_t ssize(const T (&)[N]) noexcept
-		{ return static_cast<std::ptrdiff_t>(N); }
 	template<bool B> using bool_constant = std::integral_constant<bool, B>;
 
 	enum class byte : unsigned char { };

--- a/substrate/utility
+++ b/substrate/utility
@@ -745,6 +745,49 @@ namespace substrate
 		}
 		return static_cast<T>(enc);
 	}
+
+#if __cplusplus >= 201902L
+	template<typename C>
+		[[nodiscard]] inline constexpr auto ssize(const C &c) noexcept -> decltype(std::ssize(c))
+		{ return std::ssize(c); }
+#elif _cplusplus >= 201402L
+	template<typename C>
+		SUBSTRATE_NO_DISCARD(inline constexpr auto ssize(const C &c) noexcept -> std::common_type_t<std::ptrdiff_t,
+						  std::make_signed_t<decltype(c.size())>>)
+		{ return c.size(); }
+#else
+	template<typename C>
+		SUBSTRATE_NO_DISCARD(inline std::ptrdiff_t ssize(const C &c) noexcept)
+		{ return static_cast<std::ptrdiff_t>(c.size()); }
+#endif
+
+// Otherwise covered by the clause above
+#if __cplusplus < 201902L
+	template<typename T, std::size_t N>
+		SUBSTRATE_NO_DISCARD(inline constexpr std::ptrdiff_t ssize(const T (&)[N]) noexcept)
+		{ return static_cast<std::ptrdiff_t>(N); }
+#endif
+
+#if __cplusplus >= 201411L
+	template<typename C>
+		SUBSTRATE_NO_DISCARD(inline constexpr auto size(const C &c) noexcept -> decltype(std::size(c)))
+		{ return std::size(c); }
+#elif __cplusplus >= 201402L
+	template<typename C>
+		SUBSTRATE_NO_DISCARD(inline constexpr auto size(const C &c) noexcept -> decltype(c.size()))
+		{ return c.size(); }
+#else
+	template<typename C>
+		SUBSTRATE_NO_DISCARD(inline std::size_t size(const C &c) noexcept)
+		{ return c.size(); }
+#endif
+
+// Otherwise covered by the clause above
+#if __cplusplus < 201411L
+	template<typename T, std::size_t N>
+		SUBSTRATE_NO_DISCARD(inline constexpr std::size_t size(const T (&)[N]) noexcept)
+		{ return N; }
+#endif
 } // namespace substrate
 
 #endif /* SUBSTRATE_UTILITIES */

--- a/substrate/zip_container
+++ b/substrate/zip_container
@@ -1,0 +1,300 @@
+// SPDX-License-Identifier: BSD-3-Clause
+#ifndef SUBSTRATE_ZIP_CONTAINER
+#define SUBSTRATE_ZIP_CONTAINER
+
+#include <algorithm>
+#include <iterator>
+#include <stdexcept>
+#include <tuple>
+
+#include "internal/defs"
+#include "utility"
+
+namespace substrate
+{
+	template<typename...> struct zipContainer_t;
+
+	namespace internal
+	{
+		template<typename... Iterators> struct zipIterator_t final
+		{
+		public:
+			using iterator_category = std::random_access_iterator_tag;
+			using difference_type = ssize_t;
+			using reference = std::tuple<typename std::iterator_traits<Iterators>::reference...>;
+			using value_type = std::tuple<typename std::iterator_traits<Iterators>::value_type...>;
+			using const_reference = std::tuple<add_const_t<typename std::iterator_traits<Iterators>::reference>...>;
+			using pointer = std::tuple<typename std::iterator_traits<Iterators>::pointer...>;
+
+		private:
+			static constexpr size_t length = sizeof...(Iterators);
+			size_t index;
+			size_t containerLength;
+			std::tuple<Iterators...> iterators;
+
+			zipIterator_t(const zipIterator_t &) noexcept = default;
+			zipIterator_t &operator=(const zipIterator_t &) noexcept = default;
+
+			template<size_t I> inline typename std::tuple_element<I, reference>::type get() const noexcept
+				{ return std::get<I>(iterators)[index]; }
+
+			template<size_t I> inline bool lt(const zipIterator_t<Iterators...> &rhs) const noexcept
+				{ return get<I>() < rhs.template get<I>(); }
+
+#if __cplusplus >= 201703L
+			template<size_t... Is>
+				inline bool lt(const zipIterator_t<Iterators...> &rhs, indexSequence_t<Is...>) const noexcept
+				{ return (lt<Is>(rhs) && ...); }
+#else
+			template<size_t... Is>
+				inline bool lt(const zipIterator_t<Iterators...> &rhs, indexSequence_t<Is...>) const noexcept
+			{
+				const std::array<bool, length> equals = {{lt<Is...>(rhs)}};
+				return std::all_of(equals.begin(), equals.end(), [](const bool &value) { return value; });
+			}
+#endif
+
+			template<size_t I> inline bool gt(const zipIterator_t<Iterators...> &rhs) const noexcept
+				{ return get<I>() > rhs.template get<I>(); }
+
+#if __cplusplus >= 201703L
+			template<size_t... Is>
+				inline bool gt(const zipIterator_t<Iterators...> &rhs, indexSequence_t<Is...>) const noexcept
+				{ return (gt<Is>(rhs) && ...); }
+#else
+			template<size_t... Is>
+				inline bool gt(const zipIterator_t<Iterators...> &rhs, indexSequence_t<Is...>) const noexcept
+			{
+				const std::array<bool, length> equals = {{gt<Is...>(rhs)}};
+				return std::all_of(equals.begin(), equals.end(), [](const bool &value) { return value; });
+			}
+#endif
+
+			template<size_t I> inline bool le(const zipIterator_t<Iterators...> &rhs) const noexcept
+				{ return get<I>() < rhs.template get<I>(); }
+
+#if __cplusplus >= 201703L
+			template<size_t... Is>
+				inline bool le(const zipIterator_t<Iterators...> &rhs, indexSequence_t<Is...>) const noexcept
+				{ return (le<Is>(rhs) && ...); }
+#else
+			template<size_t... Is>
+				inline bool le(const zipIterator_t<Iterators...> &rhs, indexSequence_t<Is...>) const noexcept
+			{
+				const std::array<bool, length> equals = {{le<Is...>(rhs)}};
+				return std::all_of(equals.begin(), equals.end(), [](const bool &value) { return value; });
+			}
+#endif
+
+			template<size_t I> inline bool ge(const zipIterator_t<Iterators...> &rhs) const noexcept
+				{ return get<I>() >= rhs.template get<I>(); }
+
+#if __cplusplus >= 201703L
+			template<size_t... Is>
+				inline bool ge(const zipIterator_t<Iterators...> &rhs, indexSequence_t<Is...>) const noexcept
+				{ return (ge<Is>(rhs) && ...); }
+#else
+			template<size_t... Is>
+				inline bool ge(const zipIterator_t<Iterators...> &rhs, indexSequence_t<Is...>) const noexcept
+			{
+				const std::array<bool, length> equals = {{eq<Is...>(rhs)}};
+				return std::all_of(equals.begin(), equals.end(), [](const bool &value) { return value; });
+			}
+#endif
+
+			template<size_t I> inline bool eq(const zipIterator_t<Iterators...> &rhs) const noexcept
+				{ return rhs.template get<I>() == get<I>(); }
+
+#if __cplusplus >= 201703L
+			template<size_t... Is>
+				inline bool eq(const zipIterator_t<Iterators...> &rhs, indexSequence_t<Is...>) const noexcept
+				{ return (eq<Is>(rhs) && ...); }
+#else
+			template<size_t... Is>
+				inline bool eq(const zipIterator_t<Iterators...> &rhs, indexSequence_t<Is...>) const noexcept
+			{
+				const std::array<bool, length> equals = {{eq<Is>(rhs)...}};
+				return std::all_of(equals.begin(), equals.end(), [](const bool &value) { return value; });
+			}
+#endif
+
+			template<size_t... Is> inline reference getAll(indexSequence_t<Is...>) noexcept
+#if __cplusplus >= 201703L
+				{ return {(get<Is>())...}; }
+#else
+				{ return {get<Is>()...}; }
+#endif
+
+			template<size_t... Is> inline const_reference getAll(indexSequence_t<Is...>) const noexcept
+#if __cplusplus >= 201703L
+				{ return {(get<Is>())...}; }
+#else
+				{ return {get<Is>()...}; }
+#endif
+
+		public:
+			// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
+			zipIterator_t(Iterators &&...its, size_t index, size_t containerLength) :
+				index(index), containerLength(containerLength), iterators(std::forward<Iterators>(its)...)
+			{
+				if (containerLength > static_cast<size_t>(std::numeric_limits<difference_type>::max()))
+					throw std::out_of_range("Accessing iterators beyond PTRDIFF_MAX is undefined behaviour");
+
+				if (index > containerLength)
+					throw std::out_of_range("Accessing iterators beyond boundaries is undefined behaviour");
+			}
+
+			zipIterator_t(zipIterator_t &&) noexcept = default;
+			zipIterator_t &operator=(zipIterator_t &&) noexcept = default;
+
+			~zipIterator_t() noexcept = default;
+
+			SUBSTRATE_NO_DISCARD(inline zipIterator_t operator+(const size_t value) const noexcept)
+			{
+				zipIterator_t<Iterators...> result{*this};
+				result += value;
+				return result;
+			}
+
+			SUBSTRATE_NO_DISCARD(inline zipIterator_t operator-(const size_t value) const noexcept)
+			{
+				zipIterator_t<Iterators...> result{*this};
+				result -= value;
+				return result;
+			}
+
+			inline zipIterator_t &operator+=(const size_t value)
+			{
+				if (index > std::numeric_limits<size_t>::max() - value)
+					index = std::numeric_limits<size_t>::max();
+				else
+					index = std::max<size_t>(std::min(index + value, containerLength), 0U);
+				return *this;
+			}
+
+			inline zipIterator_t &operator-=(const size_t value)
+			{
+				if (value > index)
+					index = 0;
+				else
+					index = std::max<size_t>(std::min(index - value, containerLength), 0U);
+				return *this;
+			}
+
+			inline zipIterator_t &operator++() noexcept { return *this += 1; }
+
+			// NOLINTNEXTLINE(readability-const-return-type)
+			inline const zipIterator_t operator++(int value) noexcept
+			{
+				zipIterator_t<Iterators...> result{*this};
+				if (value != 0)
+					*this += static_cast<size_t>(value);
+				else
+					*this += 1;
+				return result;
+			}
+
+			inline zipIterator_t &operator--() noexcept { return *this -= 1; }
+
+			// NOLINTNEXTLINE(readability-const-return-type)
+			inline const zipIterator_t operator--(int value) noexcept
+			{
+				zipIterator_t<Iterators...> result{*this};
+				if (value != 0)
+					*this -= static_cast<size_t>(value);
+				else
+					*this -= 1;
+				return result;
+			}
+
+			SUBSTRATE_NO_DISCARD(SUBSTRATE_CXX14_CONSTEXPR inline reference operator*() noexcept)
+				{ return getAll(makeIndexSequence<length>{});}
+
+			SUBSTRATE_NO_DISCARD(SUBSTRATE_CXX14_CONSTEXPR inline const_reference operator*() const noexcept)
+			 	{ return getAll(makeIndexSequence<length>{});}
+
+			SUBSTRATE_NO_DISCARD(SUBSTRATE_CXX14_CONSTEXPR inline reference operator[](size_t idx) noexcept)
+			{
+				zipIterator_t<Iterators...> inc{*this + idx};
+				return inc.getAll(makeIndexSequence<length>{});
+			}
+
+			SUBSTRATE_NO_DISCARD(SUBSTRATE_CXX14_CONSTEXPR inline const_reference operator[](size_t idx) const noexcept)
+			{
+				const zipIterator_t<Iterators...> inc = *this + idx;
+				return inc.getAll(makeIndexSequence<length>{});
+			}
+
+			SUBSTRATE_NO_DISCARD(inline bool operator==(const zipIterator_t<Iterators...> &rhs) const noexcept)
+				{ return eq(rhs, makeIndexSequence<length>{}); }
+
+			SUBSTRATE_NO_DISCARD(inline bool operator<(const zipIterator_t<Iterators...> &rhs) const noexcept)
+				{ return lt(rhs, makeIndexSequence<length>{}); }
+
+			SUBSTRATE_NO_DISCARD(inline bool operator<=(const zipIterator_t<Iterators...> &rhs) const noexcept)
+				{ return le(rhs, makeIndexSequence<length>{}); }
+
+			SUBSTRATE_NO_DISCARD(inline bool operator>(const zipIterator_t<Iterators...> &rhs) const noexcept)
+				{ return gt(rhs, makeIndexSequence<length>{}); }
+
+			SUBSTRATE_NO_DISCARD(inline bool operator>=(const zipIterator_t<Iterators...> &rhs) const noexcept)
+				{ return ge(rhs, makeIndexSequence<length>{}); }
+		};
+	} // namespace internal
+
+	template<typename... Ts> struct zipContainer_t final
+	{
+	private:
+		static constexpr size_t tupleLength = sizeof...(Ts);
+		size_t containerLength;
+		std::tuple<Ts...> _containers;
+
+		using iterator = internal::zipIterator_t<
+			conditional_t<std::is_const<Ts>::value, typename Ts::const_iterator, typename Ts::iterator>...>;
+		using value_type = typename iterator::reference;
+
+		template<size_t... Is> inline iterator createBeginIterator(internal::indexSequence_t<Is...>) const noexcept
+			{ return {(std::get<Is>(_containers).begin())..., 0, containerLength}; }
+
+		template<size_t... Is> inline iterator createEndIterator(internal::indexSequence_t<Is...>) const noexcept
+			{ return {(std::get<Is>(_containers).begin())..., containerLength, containerLength}; }
+
+		template<typename T> static inline bool containerMatchesLength(T &container, size_t containerLength) noexcept
+			{ return substrate::size(container) == containerLength; }
+
+	public:
+		zipContainer_t(Ts &...containers) : _containers(containers...)
+		{
+			containerLength = substrate::size(std::get<0>(_containers));
+#if __cplusplus >= 201703L
+			if ((!containerMatchesLength(containers, containerLength) || ...))
+#else
+			const std::array<size_t, tupleLength> results{{substrate::size(containers)...}};
+			if (std::any_of(results.begin(), results.end(),
+					[&](const size_t &value) noexcept { return value != containerLength; }))
+#endif
+				throw std::out_of_range("mismatching containers length");
+		}
+
+		zipContainer_t(Ts &&...containers) : _containers(containers...)
+		{
+			containerLength = substrate::size(std::get<0>(_containers));
+#if __cplusplus >= 201703L
+			if ((!containerMatchesLength(containers, containerLength) && ...))
+#else
+			const std::array<size_t, tupleLength> results{{substrate::size(containers)...}};
+			if (std::any_of(results.begin(), results.end(),
+					[&](const size_t &value) noexcept { return value != containerLength; }))
+#endif
+				throw std::out_of_range("mismatching containers length");
+		}
+
+		SUBSTRATE_NO_DISCARD(iterator begin() const noexcept)
+			{ return createBeginIterator(internal::makeIndexSequence<tupleLength>()); }
+
+		SUBSTRATE_NO_DISCARD(iterator end() const noexcept)
+			{ return createEndIterator(internal::makeIndexSequence<tupleLength>()); }
+	};
+} // namespace substrate
+
+#endif // SUBSTRATE_ZIP_CONTAINER3

--- a/test/meson.build
+++ b/test/meson.build
@@ -4,7 +4,8 @@ testSrcs = [
 	'socket.cxx', 'console.cxx', 'advanced/fd.cxx', 'span.cxx', 'conversions.cxx',
 	'bits.cxx', 'prng.cxx', 'hash.cxx', 'index_sequence.cxx', 'indexed_iterator.cxx',
 	'buffer_utils.cxx', 'pointer_utils.cxx',
-	'crypto/twofish.cxx', 'crypto/sha256.cxx', 'crypto/sha512.cxx'
+	'crypto/twofish.cxx', 'crypto/sha256.cxx', 'crypto/sha512.cxx',
+	'zip_container.cxx',
 ]
 
 if target_machine.system() == 'linux'

--- a/test/zip_container.cxx
+++ b/test/zip_container.cxx
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: BSD-3-Clause
+#include <array>
+#include <substrate/zip_container>
+#include <catch2/catch.hpp>
+
+using substrate::zipContainer_t;
+
+static constexpr std::array<uint8_t, 10> testNumsU8 =
+{{
+	0, 1, 2, 3, 4,
+	5, 6, 7, 8, 9
+}};
+
+static constexpr std::array<int16_t, 10> testNumsI16 =
+{{
+	0, 1, 2, 3, 0xFF,
+	5, 6, 7, 8, 9
+}};
+
+static constexpr std::array<int32_t, 10> testNumsI32 =
+{{
+	0, 1, 2, 3, 4,
+	5, 6, 7, 8, 9
+}};
+
+using containerIter_t = zipContainer_t<decltype(testNumsU8), decltype(testNumsI16), decltype(testNumsI32)>;
+
+TEST_CASE("zip container ctor", "[zipContainer_t]")
+{
+	containerIter_t container{testNumsU8, testNumsI16, testNumsI32};
+	(void)container;
+}
+
+TEST_CASE("zip container indexing", "[zipContainer_t]")
+{
+	containerIter_t container{testNumsU8, testNumsI16, testNumsI32};
+	auto iter = container.begin();
+	REQUIRE(std::get<0>(iter[0]) == 0);
+	REQUIRE(std::get<1>(iter[9]) == 9);
+	REQUIRE(std::get<0>(iter[4]) == 4);
+	REQUIRE(std::get<1>(iter[4]) == 0xFF);
+	REQUIRE(std::get<2>(iter[4]) == 4);
+}
+
+TEST_CASE("zip container increment", "[zipContainer_t]")
+{
+	containerIter_t container{testNumsU8, testNumsI16, testNumsI32};
+	auto iter = container.begin();
+	iter += 9;
+	{
+		auto tuple = *iter;
+		REQUIRE(std::get<0>(tuple) == 9);
+		REQUIRE(std::get<1>(tuple) == 9);
+		REQUIRE(std::get<2>(tuple) == 9);
+	}
+	++iter;
+	REQUIRE(iter == container.end());
+	REQUIRE(iter == iter++);
+	REQUIRE(iter == ++iter);
+	REQUIRE(iter == iter + 1);
+	REQUIRE(iter == iter + std::numeric_limits<decltype(iter)::difference_type>::max());
+}
+
+TEST_CASE("zip container decrement", "[zipContainer_t]")
+{
+	containerIter_t container{testNumsU8, testNumsI16, testNumsI32};
+	auto iter = container.begin();
+	iter -= 1;
+	{
+		auto tuple = *iter;
+		REQUIRE(std::get<0>(tuple) == 0);
+		REQUIRE(std::get<1>(tuple) == 0);
+		REQUIRE(std::get<2>(tuple) == 0);
+	}
+	--iter;
+	{
+		auto tuple = *iter;
+		REQUIRE(std::get<0>(tuple) == 0);
+		REQUIRE(std::get<1>(tuple) == 0);
+		REQUIRE(std::get<2>(tuple) == 0);
+	}
+	REQUIRE(iter == iter--);
+	REQUIRE(iter == --iter);
+	REQUIRE(iter == iter - 1);
+	REQUIRE(iter == iter - std::numeric_limits<decltype(iter)::difference_type>::max());
+}
+
+/* vim: set ft=cpp ts=4 sw=4 noexpandtab: */


### PR DESCRIPTION
Hi @dragonmux,

This PR implements a `zipContainer_t` meta-class that ties a tuple of containers, in order to iterate over them in tandem.

I know this needs changes and formatting, please let me know and I'll take care of it. Filing this first lets me log the comments for my own reference.