### PR TITLE
windows: Enforce usage of CFG in consumers if supported

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -88,6 +88,9 @@ if isWindows
 		language: ['c', 'cpp']
 	)
 
+	add_project_arguments(cxx.get_supported_arguments('-guard:cf'), language: ['cpp'])
+	add_project_link_arguments(cxx.get_supported_link_arguments('-guard:cf', '-Wl,-guard:cf'), language: ['cpp'])
+
 	if target_machine.cpu_family() == 'x86_64' or target_machine.cpu_family() == 'aarch64'
 		add_project_arguments('-D_WIN64', language: ['c', 'cpp'])
 	endif


### PR DESCRIPTION
Hi @dragonmux,

Just a small PR adding support for Control Flow Guard in supported compilers.

See:

- https://learn.microsoft.com/en-us/windows/win32/secbp/control-flow-guard
- https://reviews.llvm.org/D65761
- https://releases.llvm.org/16.0.0/tools/clang/docs/ReleaseNotes.html#id98