### PR TITLE
windows: Correctly remove the min/max macros

### DIFF
--- a/impl/affinity.cxx
+++ b/impl/affinity.cxx
@@ -5,7 +5,12 @@
 #include <stdexcept>
 
 #ifdef _WIN32 
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
+#endif
 #include <windows.h>
 #endif
 #if !defined(_WIN32) || defined(__WINPTHREADS_VERSION)

--- a/impl/console.cxx
+++ b/impl/console.cxx
@@ -6,12 +6,15 @@
 #ifndef _WINDOWS
 #	include <unistd.h>
 #else
+#	ifndef NOMINMAX
+#	define NOMINMAX
+#	endif
+#	ifndef WIN32_LEAN_AND_MEAN
 #	define WIN32_LEAN_AND_MEAN
+#	endif
 #	include <windows.h>
-#	include <stringapiset.h>
 #	include <fcntl.h>
 #	include <io.h>
-#	undef WIN32_LEAN_AND_MEAN
 #	include <substrate/utility>
 #endif
 #include <substrate/console>

--- a/impl/thread.cxx
+++ b/impl/thread.cxx
@@ -4,7 +4,12 @@
 #include <stdexcept>
 
 #ifdef _WIN32
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
+#endif
 #include <windows.h>
 #endif
 #if !defined(_WIN32) || defined(__WINPTHREADS_VERSION)

--- a/substrate/mmap
+++ b/substrate/mmap
@@ -8,12 +8,10 @@
 #	include <unistd.h>
 #	include <sys/mman.h>
 #else
-#	include <io.h>
+#	define NOMINMAX
 #	define WIN32_LEAN_AND_MEAN
+#	include <io.h>
 #	include <windows.h>
-#	undef WIN32_LEAN_AND_MEAN
-#	undef min
-#	undef max
 #endif
 #include <stdexcept>
 #include <cstring>

--- a/substrate/pty
+++ b/substrate/pty
@@ -29,11 +29,13 @@ namespace substrate
 	};
 } // namespace substrate
 #else
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
+#endif
 #include <Windows.h>
-#undef WIN32_LEAN_AND_MEAN
-#undef min
-#undef max
 #include <fcntl.h>
 #include <io.h>
 

--- a/substrate/socket
+++ b/substrate/socket
@@ -5,7 +5,12 @@
 #include <cstdint>
 #include <cstdlib>
 #ifdef _WIN32
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
+#endif
 #include <ws2tcpip.h>
 #undef WIN32_LEAN_AND_MEAN
 #include <type_traits>

--- a/test/affinity.cxx
+++ b/test/affinity.cxx
@@ -8,6 +8,7 @@
 #include <substrate/fixed_vector>
 
 #ifdef _WIN32 
+#define NOMINMAX
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #endif

--- a/test/socket.cxx
+++ b/test/socket.cxx
@@ -5,6 +5,7 @@
 #include <arpa/inet.h>
 #include <netinet/in.h>
 #else
+#define NOMINMAX
 #include <Winsock2.h>
 #endif
 #include <cstring>


### PR DESCRIPTION
Hi @dragonmux,

This MR is in preparation for the port to Catch2 v3 which does use much more templating than usual. It streamlines the application of `NOMINMAX` and `WIN32_LEAN_AND_MEAN` across the codebase.

Let me know what you think.