### PR TITLE
Update to Catch2 version 3 and associated fixes

### DIFF
--- a/deps/catch2.wrap
+++ b/deps/catch2.wrap
@@ -1,11 +1,11 @@
 [wrap-file]
-directory = Catch2-2.13.8
-source_url = https://github.com/catchorg/Catch2/archive/v2.13.8.tar.gz
-source_filename = Catch2-2.13.8.tar.gz
-source_hash = b9b592bd743c09f13ee4bf35fc30eeee2748963184f6bea836b146e6cc2a585a
-patch_filename = catch2_2.13.8-1_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/catch2_2.13.8-1/get_patch
-patch_hash = 3565968970ce11c1d128aa09771512047f5f9c205d2e341abf33d4a985bd0eb5
+directory = Catch2-3.3.2
+source_url = https://github.com/catchorg/Catch2/archive/v3.3.2.tar.gz
+source_filename = Catch2-3.3.2.tar.gz
+source_hash = 8361907f4d9bff3ae7c1edb027f813659f793053c99b67837a0c0375f065bae2
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/catch2_3.3.2-1/Catch2-3.3.2.tar.gz
+wrapdb_version = 3.3.2-1
 
 [provide]
 catch2 = catch2_dep
+catch2-with-main = catch2_with_main_dep

--- a/impl/meson.build
+++ b/impl/meson.build
@@ -13,7 +13,7 @@ endif
 
 deps += dependency('threads')
 
-if cxx.get_define('__cplusplus').substring(0, -1).version_compare('>=201703')
+if cxxVersion.version_compare('>=201703')
 	friendTypenameTest = '''
 		template <typename U>
 		auto foo(U u)

--- a/impl/socket.cxx
+++ b/impl/socket.cxx
@@ -1,4 +1,10 @@
 // SPDX-License-Identifier: BSD-3-Clause
+
+// https://sonarsource.atlassian.net/browse/CPP-2561
+#ifndef _CRT_USE_BUILTIN_OFFSETOF
+#define _CRT_USE_BUILTIN_OFFSETOF
+#endif
+
 #include <cstring>
 #ifndef _WIN32
 #	include <sys/socket.h>

--- a/meson.build
+++ b/meson.build
@@ -121,6 +121,8 @@ if isWindows
 	endif
 endif
 
+cxxVersion = cxx.get_define('__cplusplus').substring(0, -1)
+
 subdir('substrate')
 if get_option('build_library')
 	subdir('impl')
@@ -171,7 +173,11 @@ substrate_dep = declare_dependency(
 )
 
 if get_option('build_tests') and targetLibraryBuildable
-	subdir('test')
+	if cxxVersion.version_compare('>=201402')
+		subdir('test')
+	else
+		warning('Catch2 requires C++14 to build the tests, skipping')
+	endif
 endif
 
 # When we're in a cross-build environment, also declare the native version of the library

--- a/test/advanced/fd.cxx
+++ b/test/advanced/fd.cxx
@@ -4,7 +4,7 @@
 #include <array>
 #include <substrate/advanced/fd>
 #include <substrate/utility>
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 using substrate::advanced::fd_t;
 using substrate::make_unique;
@@ -190,7 +190,7 @@ TEST_CASE("advanced::advanced::fd_t read", "[advanced::fd_t]")
 	REQUIRE(file.isEOF());
 }
 
-ANON_TEST_CASE()
+TEST_CASE()
 {
 	unlink("fd.test");
 	SUCCEED();

--- a/test/affinity.cxx
+++ b/test/affinity.cxx
@@ -8,8 +8,12 @@
 #include <substrate/fixed_vector>
 
 #ifdef _WIN32 
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif
+#ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
+#endif
 #include <windows.h>
 #endif
 #if !defined(_WIN32) || defined(__WINPTHREADS_VERSION)
@@ -26,7 +30,7 @@
 #include <sched.h>
 #endif
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #if defined(_WIN32)
 using processorVector_t = substrate::fixedVector_t<SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX>;

--- a/test/bits.cxx
+++ b/test/bits.cxx
@@ -5,7 +5,7 @@
 #	define SUBSTRATE_CXX11_COMPAT
 #endif
 #include <substrate/bits>
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 using substrate::shift_nibble;
 TEST_CASE("shift nibble", "[bits]")

--- a/test/bounded_iterator.cxx
+++ b/test/bounded_iterator.cxx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 #include <array>
 #include <substrate/bounded_iterator>
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 using substrate::boundedIterator_t;
 

--- a/test/buffer_utils.cxx
+++ b/test/buffer_utils.cxx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 #include <cstdint>
 #include <substrate/buffer_utils>
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 constexpr static std::array<uint8_t, 2> x16LE{{0xF5U, 0xFFU}};
 constexpr static std::array<uint8_t, 4> x32LE{{0xFAU, 0xFFU, 0xFFU, 0xFFU}};

--- a/test/command_line/arguments.cxx
+++ b/test/command_line/arguments.cxx
@@ -4,7 +4,7 @@
 #include <substrate/command_line/arguments>
 #include <substrate/console>
 #include <substrate/utility>
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 using namespace std::literals::string_view_literals;
 using std::filesystem::path;

--- a/test/command_line/options.cxx
+++ b/test/command_line/options.cxx
@@ -2,7 +2,7 @@
 #include <filesystem>
 #include <substrate/conversions>
 #include <substrate/command_line/options>
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 using namespace std::literals::string_view_literals;
 using std::filesystem::path;

--- a/test/command_line/tokeniser.cxx
+++ b/test/command_line/tokeniser.cxx
@@ -2,7 +2,7 @@
 #include <array>
 #include <substrate/command_line/tokeniser>
 #include <substrate/utility>
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 using namespace std::literals::string_view_literals;
 using substrate::commandLine::internal::tokeniser_t;

--- a/test/console.cxx
+++ b/test/console.cxx
@@ -6,7 +6,7 @@
 #include <substrate/fd>
 #include <substrate/pty>
 #include <substrate/pipe>
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #ifndef _WINDOWS
 constexpr static const char *defaultTTY = "/dev/ptmx";

--- a/test/conversions.cxx
+++ b/test/conversions.cxx
@@ -4,7 +4,7 @@
 #include <chrono>
 #include <substrate/conversions>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 using substrate::fromInt_t;
 using substrate::toInt_t;

--- a/test/crypto/sha256.cxx
+++ b/test/crypto/sha256.cxx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 #include <cstdint>
 #include <substrate/crypto/sha256>
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 using namespace substrate;
 

--- a/test/crypto/sha512.cxx
+++ b/test/crypto/sha512.cxx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 #include <cstdint>
 #include <substrate/crypto/sha512>
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 using namespace substrate;
 TEST_CASE("sha512: empty hash", "[crypto/sha256]")

--- a/test/crypto/twofish.cxx
+++ b/test/crypto/twofish.cxx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 #include <cstdint>
 #include <substrate/crypto/twofish>
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 using namespace substrate;
 

--- a/test/enum_utils.cxx
+++ b/test/enum_utils.cxx
@@ -3,7 +3,7 @@
 #include <string>
 #include <vector>
 #include <substrate/enum_utils>
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 enum class Flags : uint8_t
 {

--- a/test/fd.cxx
+++ b/test/fd.cxx
@@ -5,7 +5,7 @@
 #include <substrate/fixed_vector>
 #include <substrate/fd>
 #include <substrate/utility>
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 using substrate::fd_t;
 using substrate::make_unique;
@@ -191,7 +191,7 @@ TEST_CASE("fd_t read", "[fd_t]")
 	REQUIRE(file.isEOF());
 }
 
-ANON_TEST_CASE()
+TEST_CASE()
 {
 	unlink("fd.test");
 	SUCCEED();

--- a/test/fixed_vector.cxx
+++ b/test/fixed_vector.cxx
@@ -3,7 +3,7 @@
 #include <string>
 #include <substrate/fixed_vector>
 #include <substrate/internal/defs>
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 using substrate::fixedVector_t;
 using substrate::vectorStateException_t;

--- a/test/hash.cxx
+++ b/test/hash.cxx
@@ -5,7 +5,7 @@
 #	define SUBSTRATE_CXX11_COMPAT
 #endif
 #include <substrate/hash>
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 
 

--- a/test/index_sequence.cxx
+++ b/test/index_sequence.cxx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 #include <cstdint>
 #include <substrate/index_sequence>
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 using substrate::indexIterator_t;
 using substrate::indexSequence_t;

--- a/test/indexed_iterator.cxx
+++ b/test/indexed_iterator.cxx
@@ -2,7 +2,7 @@
 #include <cstdint>
 #include <array>
 #include <substrate/indexed_iterator>
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 using substrate::indexedIterator_t;
 

--- a/test/managed_ptr.cxx
+++ b/test/managed_ptr.cxx
@@ -1,6 +1,6 @@
 #include <cstdint>
 #include <substrate/managed_ptr>
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 using substrate::managedPtr_t;
 using substrate::make_managed;

--- a/test/memfd.cxx
+++ b/test/memfd.cxx
@@ -5,7 +5,7 @@
 #include <array>
 #include <substrate/memfd>
 #include <substrate/utility>
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 using substrate::memfd_t;
 using substrate::make_unique;

--- a/test/mmap.cxx
+++ b/test/mmap.cxx
@@ -3,7 +3,7 @@
 #include <substrate/memfd>
 #include <substrate/fd>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <cstring>
 
 using substrate::mmap_t;

--- a/test/pointer_utils.cxx
+++ b/test/pointer_utils.cxx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 #include <array>
 #include <substrate/pointer_utils>
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #if defined(SUBSTRATE_SUPPORTS_MANAGED_TUPLE)
 

--- a/test/prng.cxx
+++ b/test/prng.cxx
@@ -5,7 +5,7 @@
 #	define SUBSTRATE_CXX11_COMPAT
 #endif
 #include <substrate/prng>
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 
 

--- a/test/socket.cxx
+++ b/test/socket.cxx
@@ -5,12 +5,14 @@
 #include <arpa/inet.h>
 #include <netinet/in.h>
 #else
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif
 #include <Winsock2.h>
 #endif
 #include <cstring>
 #include <substrate/socket>
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 using substrate::socket_t;
 using substrate::socketType_t;

--- a/test/span.cxx
+++ b/test/span.cxx
@@ -1,2 +1,2 @@
 #include <substrate/span>
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>

--- a/test/string.cxx
+++ b/test/string.cxx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 #include <cstring>
 #include <substrate/string>
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 using substrate::stringDup;
 using substrate::stringsLength;

--- a/test/test.cxx
+++ b/test/test.cxx
@@ -4,7 +4,8 @@
 #include <crtdbg.h>
 #endif
 #define CATCH_CONFIG_RUNNER
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_session.hpp>
 
 #ifdef _WINDOWS
 void invalidHandler(const wchar_t *, const wchar_t *, const wchar_t *, const uint32_t, const uintptr_t) { }

--- a/test/thread_pool.cxx
+++ b/test/thread_pool.cxx
@@ -8,7 +8,7 @@
 #include <substrate/utility>
 #include <substrate/thread_pool>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 namespace
 {

--- a/test/thread_pool.cxx
+++ b/test/thread_pool.cxx
@@ -57,14 +57,24 @@ TEST_CASE("unused", "[threadPool_t]")
 TEST_CASE("once", "[threadPool_t]")
 {
 	auto pool{substrate::make_unique_nothrow<substrate::threadPool_t<decltype(dummyWork)>>(dummyWork)};
+	std::atomic<uint32_t> fence{};
 	REQUIRE(pool);
+	fence++;
 	REQUIRE(pool->valid());
+	fence++;
 	REQUIRE(pool->ready());
+	fence++;
 	REQUIRE(!pool->queue());
+	fence++;
 	REQUIRE(pool->valid());
+	fence++;
 	REQUIRE(pool->finish());
+	fence++;
 	REQUIRE(!pool->valid());
+	fence++;
 	REQUIRE(!pool->finish());
+	fence++;
+	REQUIRE(fence == 8);
 }
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)

--- a/test/threaded_queue.cxx
+++ b/test/threaded_queue.cxx
@@ -5,7 +5,7 @@
 #include <substrate/latch>
 #include <substrate/threaded_queue>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 TEST_CASE("empty", "[threadedQueue_t]")
 {

--- a/test/units.cxx
+++ b/test/units.cxx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 #include <cstdint>
 #include <substrate/units>
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 using substrate::operator ""_KiB;
 using substrate::operator ""_MiB;

--- a/test/utility.cxx
+++ b/test/utility.cxx
@@ -9,7 +9,7 @@
 #endif
 #include <substrate/internal/defs>
 #include <substrate/utility>
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 namespace test
 {

--- a/test/zip_container.cxx
+++ b/test/zip_container.cxx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 #include <array>
 #include <substrate/zip_container>
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 using substrate::zipContainer_t;
 


### PR DESCRIPTION
Hi @dragonmux,

This PR upgrades your test suite to use Catch2 version. There's an overlap with #52 because it's needed to build this one, it'll go away as soon as the former is approved.

This also includes the fencing commit you told me about, let me know if we should instead drop the inlining of threadedQueue_t and threadPool_t.