### PR TITLE
Fix Windows shenanigans

### DIFF
--- a/impl/meson.build
+++ b/impl/meson.build
@@ -1,12 +1,14 @@
 # SPDX-License-Identifier: BSD-3-Clause
 libSubstrateSrcs = [
 	'socket.cxx', 'console.cxx', 'affinity.cxx', 'thread.cxx',
+	'utility.cxx',
 ]
 
 deps = []
 
 if target_machine.system() == 'windows'
-	deps += cxx.find_library('ws2_32')
+	deps += cxx.find_library('ws2_32', required: true)
+	deps += cxx.find_library('dbghelp', required: true)
 else
 	libSubstrateSrcs += 'pty.cxx'
 endif

--- a/impl/utility.cxx
+++ b/impl/utility.cxx
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+#ifdef _WIN32
+#include <windows.h>
+#include <dbghelp.h>
+#endif
+#ifndef _MSC_VER
+#include <cxxabi.h>
+#endif
+
+#include <string>
+#include <system_error>
+#include <vector>
+
+#include "substrate/utility"
+
+namespace substrate
+{
+	std::string decode_typename(const char *const mangledName)
+	{
+#ifndef _MSC_VER
+		int status{};
+		auto *const demangler{abi::__cxa_demangle(mangledName, nullptr, nullptr, &status)};
+		if (status == -1)
+			throw std::runtime_error("A memory allocation failure occurred");
+		else if (status == -3)
+			return {mangledName};
+		else if (status == 0)
+		{
+			std::unique_ptr<char, void (*)(void *)> _demangle{demangler, std::free};
+			return {_demangle ? _demangle.get() : mangledName};
+		}
+		// status == 2 -- fallthrough
+#endif
+#ifdef _WIN32
+		std::vector<char> buffer(2048U);
+		const auto result{UnDecorateSymbolName(mangledName, buffer.data(), 2048U, UNDNAME_COMPLETE)};
+		if (result != 0)
+			return {buffer.data()};
+		throw std::system_error(static_cast<int>(GetLastError()), std::system_category());
+#endif
+	}
+} // namespace substrate

--- a/meson.build
+++ b/meson.build
@@ -167,6 +167,7 @@ endif
 substrate_dep = declare_dependency(
 	dependencies: deps,
 	include_directories: include_directories('.'),
+	compile_args: variablesCompileArgs,
 	link_with: libSubstrate,
 	variables: variables,
 	version: meson.project_version()
@@ -182,12 +183,14 @@ endif
 
 # When we're in a cross-build environment, also declare the native version of the library
 if meson.is_cross_build()
+	substrateNativeArgs = ' '.join(['-I@0@'.format(meson.current_source_dir())] + libSubstrateArgs)
 	substrate_native_dep = declare_dependency(
 		dependencies: deps,
 		include_directories: include_directories('.'),
+		compile_args: substrateNativeArgs,
 		link_with: libSubstrateNative,
 		variables: {
-			'compile_args': ' '.join(['-I@0@'.format(meson.current_source_dir())] + libSubstrateArgs),
+			'compile_args': substrateNativeArgs,
 			'link_args': libSubstrateNative.full_path()
 		},
 		version: meson.project_version()

--- a/substrate/thread_pool
+++ b/substrate/thread_pool
@@ -33,7 +33,7 @@ namespace substrate
 		affinity_t affinity{};
 		workFunc_t workerFunction;
 
-		std::pair<bool, std::tuple<args_t...>> waitWork() noexcept
+		inline std::pair<bool, std::tuple<args_t...>> waitWork() noexcept
 		{
 			std::unique_lock<std::mutex> lock{workMutex};
 			++waitingThreads;
@@ -50,16 +50,16 @@ namespace substrate
 		}
 
 		template<std::size_t... indicies>
-			SUBSTRATE_NO_DISCARD(result_t invoke(std::tuple<args_t...> &&args,
+			SUBSTRATE_NO_DISCARD(inline result_t invoke(std::tuple<args_t...> &&args,
 			internal::indexSequence_t<indicies...>))
 			{ return workerFunction(std::get<indicies>(std::move(args))...); }
 
 		template<std::size_t I, substrate::enable_if_t<I == 0, void>* = nullptr>
-			SUBSTRATE_NO_DISCARD(result_t ctad_invoke(std::tuple<args_t...> &&))
+			SUBSTRATE_NO_DISCARD(inline result_t ctad_invoke(std::tuple<args_t...> &&))
 			{ return workerFunction(); }
 
 		template<std::size_t I, typename substrate::enable_if_t<I != 0, void>* = nullptr>
-			SUBSTRATE_NO_DISCARD(result_t ctad_invoke(std::tuple<args_t...> &&args))
+			SUBSTRATE_NO_DISCARD(inline result_t ctad_invoke(std::tuple<args_t...> &&args))
 			{ return invoke(std::move(args), internal::makeIndexSequence<I>{}); }
 
 		void workerThread(const std::size_t processor) noexcept
@@ -76,14 +76,14 @@ namespace substrate
 			}
 		}
 
-		result_t clearResultQueue() noexcept
+		inline result_t clearResultQueue() noexcept
 		{
 			result_t result{};
 			while (!results.empty())
 			{
 				auto thisResult = results.pop();
 				if (!result)
-					std::swap(result, thisResult);
+					result = std::move(thisResult);
 			}
 			return result;
 		}
@@ -103,9 +103,9 @@ namespace substrate
 		threadPool_t &operator =(const threadPool_t &) = delete;
 		threadPool_t &operator =(threadPool_t &&) = delete;
 
-		SUBSTRATE_NO_DISCARD(size_t numProcessors() const noexcept) { return affinity.numProcessors(); }
-		SUBSTRATE_NO_DISCARD(bool valid() const noexcept) { return !threads.empty(); }
-		SUBSTRATE_NO_DISCARD(bool ready() const noexcept) { return waitingThreads == affinity.numProcessors(); }
+		SUBSTRATE_NO_DISCARD(inline size_t numProcessors() const noexcept) { return affinity.numProcessors(); }
+		SUBSTRATE_NO_DISCARD(inline bool valid() const noexcept) { return !threads.empty(); }
+		SUBSTRATE_NO_DISCARD(inline bool ready() const noexcept) { return waitingThreads == affinity.numProcessors(); }
 
 		SUBSTRATE_NO_DISCARD(result_t queue(args_t ...args) noexcept)
 		{

--- a/substrate/utility
+++ b/substrate/utility
@@ -15,10 +15,6 @@
 #include <substrate/internal/defs>
 #include <substrate/promotion_helpers>
 
-#ifndef _MSC_VER
-#include <cxxabi.h>
-#endif
-
 namespace substrate
 {
 /* C++ 14 helpers */
@@ -545,18 +541,9 @@ namespace substrate
 	template<typename T> struct is_pod : public std::integral_constant<bool,
 		std::is_trivial<T>::value && std::is_standard_layout<T>::value> { };
 
-#if !defined(__GNUC__) || defined(__GXX_RTTI)
+#if defined(_MSC_VER) || !defined(__GNU__) || defined(__GXX_RTTI)
 	/* typename decoding */
-	SUBSTRATE_NOWARN_UNUSED(static inline std::string decode_typename(const char *const mangled_name))
-	{
-#ifndef _MSC_VER
-		auto * const demangler = abi::__cxa_demangle(mangled_name, nullptr, nullptr, nullptr);
-#else
-		const auto demangler = nullptr;
-#endif
-		std::unique_ptr<char, void(*)(void*)> _demangle{demangler, std::free};
-		return {_demangle ? _demangle.get() : mangled_name};
-	}
+	SUBSTRATE_NOWARN_UNUSED(SUBSTRATE_CLS_API std::string decode_typename(const char *mangledName));
 
 	template<typename T> static std::string decode_typename()
 	{

--- a/test/affinity.cxx
+++ b/test/affinity.cxx
@@ -70,13 +70,13 @@ static void nextProcessor(const processorVector_t &processorInfo,
 		for (; groupIndex < processor.Group.ActiveGroupCount; ++groupIndex)
 		{
 			const auto &group{processor.Group.GroupInfo[groupIndex]};
-			for (; maskOffset < sizeof(KAFFINITY) * 8; ++maskOffset)
+			for (; maskOffset < sizeof(KAFFINITY) * 8U; ++maskOffset)
 			{
 				const auto mask{group.ActiveProcessorMask >> maskOffset};
-				if (mask & 1)
+				if (mask & 0x1U)
 					return;
 			}
-			maskOffset = 0;
+			maskOffset = 0U;
 		}
 		++info;
 	}
@@ -170,7 +170,7 @@ TEST_CASE("pinning", "[affinity_t]")
 		REQUIRE(result == static_cast<int32_t>(processor));
 	}
 #elif defined(_WIN32)
-	std::size_t count{0};
+	uint32_t count{0};
 	for (const auto &processor : *affinity)
 	{
 		const auto result = std::async(std::launch::async,

--- a/test/utility.cxx
+++ b/test/utility.cxx
@@ -1951,6 +1951,13 @@ TEST_CASE("C++ typename decoding", "[utility]")
 	REQUIRE(decode_typename<I>() == "int* const volatile");
 	REQUIRE(decode_typename<Iu>() == "unsigned int* const volatile");
 #endif
+
+#ifdef _WIN32
+	REQUIRE(decode_typename("?decode_typename@substrate@@YA?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@PEBD@Z") == "class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > __cdecl substrate::decode_typename(char const * __ptr64)");
+#endif
+#ifndef _MSC_VER
+	REQUIRE(decode_typename("_ZN9substrate15decode_typenameEPKc") == "substrate::decode_typename(char const*)");
+#endif
 }
 
 using substrate::leb128_decode;


### PR DESCRIPTION
Hi @dragonmux,

This PR fixes some assorted tidbits I found earlier this week.

- Implemented demangling for MSVC through Windows's dbghelp library
- Fixed some loss of precision warnings in affinity_t (mainly caused by discrepancies in how Windows returns processor groups)
- Re-enabled the inlining in threadPool_t, except in the consumer functions for the sake of safety
- Fixed LTO building failure because compile_args isn't exposed anymore in Meson since 1.1.0

Let me know what you think.