### PR TITLE
zipContainer_t: Fix typo in the forwarding ctor

### DIFF
--- a/substrate/zip_container
+++ b/substrate/zip_container
@@ -280,7 +280,7 @@ namespace substrate
 		{
 			containerLength = substrate::size(std::get<0>(_containers));
 #if __cplusplus >= 201703L
-			if ((!containerMatchesLength(containers, containerLength) && ...))
+			if ((!containerMatchesLength(containers, containerLength) || ...))
 #else
 			const std::array<size_t, tupleLength> results{{substrate::size(containers)...}};
 			if (std::any_of(results.begin(), results.end(),


### PR DESCRIPTION
Hi @dragonmux,

This PR fixes a small typo in the forwarding ctor of zipContainer_t.

Unsure if we should drop the reference-backed one too, so that we allow full and consistent coverage.

Let me know what you think.