### PR TITLE
utility: Port std::data too

### DIFF
--- a/substrate/span
+++ b/substrate/span
@@ -25,10 +25,6 @@ namespace substrate
 {
 	template<typename...> using void_t = void;
 
-	template<typename C> constexpr auto data(C &c) -> decltype(c.data()) { return c.data(); }
-	template<typename C> constexpr auto data(const C &c) -> decltype(c.data()) { return c.data(); }
-	template<typename T, std::size_t N> constexpr T *data(T (&array)[N]) noexcept { return array; }
-	template<typename E> constexpr const E *data(std::initializer_list<E> il) noexcept { return il.data(); }
 	template<bool B> using bool_constant = std::integral_constant<bool, B>;
 
 	enum class byte : unsigned char { };

--- a/substrate/utility
+++ b/substrate/utility
@@ -775,6 +775,16 @@ namespace substrate
 		SUBSTRATE_NO_DISCARD(inline constexpr std::size_t size(const T (&)[N]) noexcept)
 		{ return N; }
 #endif
+
+#if __cplusplus >= 201711L
+	template <class C> constexpr auto data(C&& c) noexcept -> decltype(std::data(c))
+		{ return std::data(std::forward(c)); }
+#else
+	template<typename C> SUBSTRATE_NO_DISCARD(inline SUBSTRATE_CXX14_CONSTEXPR auto data(C &c)) -> decltype(c.data()) { return c.data(); }
+	template<typename C> SUBSTRATE_NO_DISCARD(inline SUBSTRATE_CXX14_CONSTEXPR auto data(const C &c)) -> decltype(c.data()) { return c.data(); }
+	template<typename T, std::size_t N> SUBSTRATE_NO_DISCARD(inline SUBSTRATE_CXX14_CONSTEXPR T *data(T (&array)[N]) noexcept) { return array; }
+	template<typename E> SUBSTRATE_NO_DISCARD(inline SUBSTRATE_CXX14_CONSTEXPR const E *data(std::initializer_list<E> il) noexcept) { return il.begin(); }
+#endif
 } // namespace substrate
 
 #endif /* SUBSTRATE_UTILITIES */


### PR DESCRIPTION
Hi @dragonmux,

As in #44, it seems that you implemented `std::data` for pre-17, but without porting it  into `utility`. This PR does just that, allowing me to implement STL container compatibility for all hash functions.

Let me know what you think.