### PR TITLE
Implement STL container compatibility for checksum functions

### DIFF
--- a/substrate/hash
+++ b/substrate/hash
@@ -8,10 +8,10 @@
 #include <cstring>
 #include <limits>
 #include <type_traits>
-#include <utility>
 
-#include <substrate/internal/defs>
-#include <substrate/bits>
+#include "substrate/internal/defs"
+#include "substrate/bits"
+#include "substrate/utility"
 
 namespace substrate
 {
@@ -30,11 +30,11 @@ namespace substrate
 		}
 	}
 
-	template<typename T, size_t N> std::pair<std::uint64_t, std::uint64_t>
-		murmur128(const std::array<T, N>& input, const uint32_t seed)
+	template<typename Sized> std::pair<std::uint64_t, std::uint64_t>
+		murmur128(const Sized& input, const uint32_t seed)
 	{
-		constexpr std::uint64_t len{sizeof(T) * N};
-		constexpr size_t blk_count{len / 16};
+		SUBSTRATE_CXX14_CONSTEXPR std::uint64_t len{sizeof(typename Sized::value_type) * substrate::size(input)};
+		SUBSTRATE_CXX14_CONSTEXPR size_t blk_count{len / 16};
 		constexpr std::uint64_t c1 = 0x87C37B91114253D5ULL;
 		constexpr std::uint64_t c2 = 0x4CF5AD432745937FULL;
 		const auto data{static_cast<const uint8_t*>(static_cast<const void*>(input.data()))};

--- a/substrate/hash
+++ b/substrate/hash
@@ -31,16 +31,16 @@ namespace substrate
 	}
 
 	template<typename Sized> std::pair<std::uint64_t, std::uint64_t>
-		murmur128(const Sized& input, const uint32_t seed)
+		murmur128(const Sized& input, const uint32_t seed) noexcept
 	{
 		SUBSTRATE_CXX14_CONSTEXPR std::uint64_t len{sizeof(typename Sized::value_type) * substrate::size(input)};
 		SUBSTRATE_CXX14_CONSTEXPR size_t blk_count{len / 16};
-		constexpr std::uint64_t c1 = 0x87C37B91114253D5ULL;
-		constexpr std::uint64_t c2 = 0x4CF5AD432745937FULL;
-		const auto data{static_cast<const uint8_t*>(static_cast<const void*>(input.data()))};
+		static constexpr std::uint64_t c1{UINT64_C(0x87C37B91114253D5)};
+		static constexpr std::uint64_t c2{UINT64_C(0x4CF5AD432745937F)};
+		const auto *const data{static_cast<const uint8_t*>(static_cast<const void*>(input.data()))};
 
-		std::uint64_t h1 = seed;
-		std::uint64_t h2 = seed;
+		std::uint64_t h1{seed};
+		std::uint64_t h2{seed};
 
 		for (size_t idx{}; idx < blk_count; ++idx)
 		{

--- a/substrate/hash
+++ b/substrate/hash
@@ -183,8 +183,11 @@ namespace substrate
 		return std::uint16_t(chksum);
 	}
 
-	template<std::size_t N> std::uint16_t bsd_checksum(std::array<std::uint8_t, N> bytes) noexcept
-		{ return bsd_checksum(bytes.data(), N); }
+	template<typename Sized> inline uint16_t bsd_checksum(const Sized &data) noexcept
+	{
+		// NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+		return bsd_checksum(reinterpret_cast<const uint8_t *>(substrate::data(data)), substrate::size(data));
+	}
 }
 
 #endif /* SUBSTRATE_HASH */

--- a/substrate/hash
+++ b/substrate/hash
@@ -161,8 +161,11 @@ namespace substrate
 		return std::uint16_t((res % m16) + res / m16);
 	}
 
-	template<std::size_t N> std::uint16_t sysv_checksum(std::array<std::uint8_t, N> bytes) noexcept
-		{ return sysv_checksum(bytes.data(), N); }
+	template<typename Sized> inline uint16_t sysv_checksum(const Sized &data) noexcept
+	{
+		// NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+		return sysv_checksum(reinterpret_cast<const uint8_t *>(substrate::data(data)), substrate::size(data));
+	}
 
 	std::uint16_t bsd_checksum(const std::uint8_t* bytes, std::size_t len) noexcept
 	{


### PR DESCRIPTION
Hi @dragonmux,

We continue tonight with adding STL compatibility, through `std::data` and `std::size`, to the checksum functions in `hash`.

The next two PRs will implement tests and CRC32 :O

Let me know what you think.