### PR TITLE
Implement CRC32

### DIFF
--- a/impl/hash.cxx
+++ b/impl/hash.cxx
@@ -1,0 +1,5 @@
+#include "substrate/hash"
+
+#if __cplusplus < 201703L
+const std::array<const uint32_t, 256> substrate::crc32_t::crcTable;
+#endif

--- a/impl/meson.build
+++ b/impl/meson.build
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 libSubstrateSrcs = [
 	'socket.cxx', 'console.cxx', 'affinity.cxx', 'thread.cxx',
-	'utility.cxx',
+	'utility.cxx', 'hash.cxx',
 ]
 
 deps = []

--- a/substrate/hash
+++ b/substrate/hash
@@ -188,7 +188,78 @@ namespace substrate
 		// NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
 		return bsd_checksum(reinterpret_cast<const uint8_t *>(substrate::data(data)), substrate::size(data));
 	}
-}
+
+	// crc32
+	namespace
+	{
+		SUBSTRATE_NOWARN_UNUSED(inline constexpr uint32_t calcPolynomial(const uint8_t bit) noexcept)
+			{ return 1U << (31U - bit);	}
+		// We cannot use fold expansion here because it exhausts
+		// Clang's 512 iterations limit on constexpr calculation
+		template<typename T, typename... U>
+			inline constexpr enable_if_t<sizeof...(U) != 0, uint32_t> calcPolynomial(T bit, U... bits) noexcept
+				{ return calcPolynomial(bit) | calcPolynomial(bits...); }
+
+		template<uint8_t bit> inline constexpr uint32_t calcPolynomial() noexcept { return 1U << (31U - bit); }
+		template<uint8_t bit, uint8_t... bits>
+			inline constexpr enable_if_t<sizeof...(bits) != 0, uint32_t> calcPolynomial() noexcept
+				{ return calcPolynomial<bit>() | calcPolynomial<bits...>(); }
+
+		inline constexpr uint32_t calcTableC(const uint32_t polynomial, const uint32_t byte, const uint8_t bitIdx) noexcept
+			{
+				return bitIdx ? calcTableC(polynomial, ((byte & 1U) == 1U ? polynomial : 0U) ^ (byte >> 1U), static_cast<uint8_t>(bitIdx - 1U)) : byte;
+			}
+
+		// Generate CRC for byte 'n'
+		inline constexpr uint32_t calcCrcAtByte(const uint32_t poly, const uint8_t byte) noexcept
+			{ return calcTableC(poly, byte, 8); }
+
+		template<uint8_t N, uint32_t poly, uint32_t... table> struct calcTable
+		{
+			constexpr static std::array<const uint32_t, sizeof...(table) + N + 1U> value
+			{
+				calcTable<N - 1U, poly, calcCrcAtByte(poly, N), table...>::value
+			};
+		};
+
+		template<uint32_t poly, uint32_t... table> struct calcTable<0, poly, table...>
+		{
+			constexpr static std::array<const uint32_t, sizeof...(table) + 1> value{{calcCrcAtByte(poly, 0), table...}};
+		};
+	} // namespace
+
+	struct crc32_t final
+	{
+	private:
+		constexpr static uint32_t poly{calcPolynomial<0U, 1U, 2U, 4U, 5U, 7U, 8U, 10U, 11U, 12U, 16U, 22U, 23U, 26U>()};
+		static_assert(poly == 0xEDB88320U, "Polynomial calculation failure");
+		SUBSTRATE_CLS_API constexpr static std::array<const uint32_t, 256> crcTable{calcTable<255, poly>::value};
+
+	public:
+		static uint32_t crc(const uint8_t *data, size_t dataLen) noexcept
+			{
+				uint32_t crc{};
+				crc ^= std::numeric_limits<decltype(crc)>::max();
+				while (dataLen > 0)
+				{
+					crc = crcTable.at(uint8_t(crc ^ *data++)) ^ (crc >> 8U);
+					dataLen--;
+				}
+				crc ^= std::numeric_limits<decltype(crc)>::max();
+				return crc;
+			}
+
+		crc32_t() = delete;
+	};
+
+	static inline uint32_t crc32(const uint8_t *data, size_t dataLen) noexcept { return crc32_t::crc(data, dataLen); }
+
+	template<typename Sized> static inline uint32_t crc32(const Sized &data) noexcept
+		{
+			// NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+			return crc32(reinterpret_cast<const uint8_t *>(substrate::data(data)), substrate::size(data));
+		}
+} // namespace substrate
 
 #endif /* SUBSTRATE_HASH */
 /* vim: set ft=cpp ts=4 sw=4 noexpandtab: */

--- a/test/hash.cxx
+++ b/test/hash.cxx
@@ -57,4 +57,18 @@ TEST_CASE("sysv", "[hash]")
 	REQUIRE(substrate::sysv_checksum(example2) == 0x1007);
 }
 
+TEST_CASE("crc32", "[hash]")
+{
+	// https://github.com/emn178/js-crc/blob/master/README.md
+	const std::string empty{};
+	const std::array<uint8_t, 1> zero{{0x0}};
+	const std::string example{"The quick brown fox jumps over the lazy dog"};
+	const std::string example2{"The quick brown fox jumps over the lazy dog."};
+
+	REQUIRE(substrate::crc32(empty) == UINT32_C(0x00000000));
+	REQUIRE(substrate::crc32(zero) == UINT32_C(0xD202EF8D));
+	REQUIRE(substrate::crc32(example) == UINT32_C(0x414FA339));
+	REQUIRE(substrate::crc32(example2) == UINT32_C(0x519025E9));
+}
+
 /* vim: set ft=cpp ts=4 sw=4 noexpandtab: */


### PR DESCRIPTION
Hi @dragonmux,

This PR implements compile-time (where possible) CRC32. I based it on an old Godbolt of yours, and adjusted the necessary bits to make it compatible all the way back to C++11.

Depends on #59 passing and being merged, so marking as draft and submitting for your review (ignore all but the last commit).

Let me know what you think.