### PR TITLE
utility: Fix decode_typename not returning a value in non-Linux + non-Windows 

### DIFF
--- a/impl/utility.cxx
+++ b/impl/utility.cxx
@@ -37,7 +37,9 @@ namespace substrate
 		const auto result{UnDecorateSymbolName(mangledName, buffer.data(), 2048U, UNDNAME_COMPLETE)};
 		if (result != 0)
 			return {buffer.data()};
-		throw std::system_error(static_cast<int>(GetLastError()), std::system_category());
+		else
+			throw std::system_error(static_cast<int>(GetLastError()), std::system_category());
 #endif
+		return mangledName;
 	}
 } // namespace substrate

--- a/test/utility.cxx
+++ b/test/utility.cxx
@@ -1954,10 +1954,14 @@ TEST_CASE("C++ typename decoding", "[utility]")
 
 #ifdef _WIN32
 	REQUIRE(decode_typename("?decode_typename@substrate@@YA?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@PEBD@Z") == "class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > __cdecl substrate::decode_typename(char const * __ptr64)");
+	REQUIRE(decode_typename("?crcTable@crc32_t@substrate@@0V?$array@$$CBI$0BAA@@std@@B") == "private: static class std::array<unsigned int const ,256> const substrate::crc32_t::crcTable");
 #endif
-#ifndef _MSC_VER
+#ifndef _MSC_VER // Itanium
 	REQUIRE(decode_typename("_ZN9substrate15decode_typenameEPKc") == "substrate::decode_typename(char const*)");
+	REQUIRE(decode_typename("_ZN9substrate7crc32_t8crcTableE") == "substrate::crc32_t::crcTable");
 #endif
+
+	REQUIRE(decode_typename("hello world") == "hello world");
 }
 
 using substrate::leb128_decode;


### PR DESCRIPTION
Hi @dragonmux,

Here's a PR to fix an issue that AppleClang detected in decode_typename. The fallback I implemented for MinGW (first try Itanium if available, then Win32 also if available) did not return a value if the former failed and the latter wasn't available-- which is the case in macOS.

Let me know what you think.