### PR TITLE
Fix: mmap_t on windows

### DIFF
--- a/substrate/fd
+++ b/substrate/fd
@@ -55,7 +55,13 @@ namespace substrate
 #endif
 		fd_t(fd_t &&fd_) noexcept : fd_t{} { swap(fd_); }
 		~fd_t() noexcept { if (fd != -1) close(fd); }
-		void operator =(fd_t &&fd_) noexcept { swap(fd_); }
+
+		fd_t &operator =(fd_t &&fd_) noexcept
+		{
+			swap(fd_);
+			return *this;
+		}
+
 		SUBSTRATE_NO_DISCARD(operator int32_t() const noexcept) { return fd; }
 		SUBSTRATE_NO_DISCARD(bool operator ==(const int32_t desc) const noexcept) { return fd == desc; }
 		SUBSTRATE_NO_DISCARD(bool valid() const noexcept) { return fd != -1; }
@@ -406,7 +412,7 @@ namespace substrate
 		fd_t &operator =(const fd_t &) = delete;
 	};
 
-	inline void swap(fd_t &a, fd_t &b) noexcept { a.swap(b); }
+	inline void swap(fd_t &lhs, fd_t &rhs) noexcept { lhs.swap(rhs); }
 #ifndef _WINDOWS
 	// NOLINTNEXTLINE(hicpp-signed-bitwise)
 	SUBSTRATE_NOWARN_UNUSED(constexpr static mode_t normalMode) = S_IWUSR | S_IRUSR | S_IRGRP | S_IROTH;

--- a/substrate/fd
+++ b/substrate/fd
@@ -18,9 +18,7 @@
 #	include <substrate/utility>
 #endif
 
-#ifndef _WINDOWS
-#	include <substrate/mmap>
-#endif
+#include <substrate/mmap>
 
 #if defined(SUBSTRATE_ALLOW_STD_FILESYSTEM_PATH)
 #include <filesystem>
@@ -387,7 +385,6 @@ namespace substrate
 			return seek(offset, SEEK_CUR) == currentPos + offset;
 		}
 
-#ifndef _WINDOWS
 		SUBSTRATE_NO_DISCARD(mmap_t map(const int32_t prot, const int flags = MAP_SHARED) noexcept)
 		{
 			const auto len{length()};
@@ -404,7 +401,6 @@ namespace substrate
 			invalidate();
 			return {file, len, prot, flags, map_addr};
 		}
-#endif
 
 		fd_t(const fd_t &) = delete;
 		fd_t &operator =(const fd_t &) = delete;

--- a/substrate/mmap
+++ b/substrate/mmap
@@ -29,10 +29,15 @@
 namespace substrate
 {
 #ifdef _WIN32
+	static constexpr DWORD PROT_READ{PAGE_READONLY};
+	static constexpr DWORD PROT_WRITE{PAGE_READWRITE};
+	static constexpr int32_t MAP_PRIVATE{0};
+	static constexpr int32_t MAP_FAILED{-1};
+	static constexpr int32_t MAP_SHARED{0};
 
-	const auto MADV_SEQUENTIAL{0};
-	const auto MADV_WILLNEED{0};
-	const auto MADV_DONTDUMP{0};
+	static constexpr auto MADV_SEQUENTIAL{0};
+	static constexpr auto MADV_WILLNEED{0};
+	static constexpr auto MADV_DONTDUMP{0};
 #endif
 
 	struct mmap_t final

--- a/substrate/mmap
+++ b/substrate/mmap
@@ -137,7 +137,7 @@ namespace substrate
 
 		SUBSTRATE_NO_DISCARD(SUBSTRATE_CXX14_CONSTEXPR bool valid() const noexcept) { return _addr; }
 #else
-		mmap_t(const fd_t &fd, const std::size_t len, const DWORD prot, const int32_t = 0,
+		mmap_t(const int32_t fd, const std::size_t len, const DWORD prot, const int32_t = 0,
 			void * = nullptr) noexcept : _len{len}, _mapping{[&]() noexcept -> HANDLE
 			{
 				const auto file = reinterpret_cast<HANDLE>(_get_osfhandle(fd));
@@ -151,7 +151,7 @@ namespace substrate
 				return MapViewOfFile(_mapping, protToAccess(prot), 0, 0, 0);
 			}()} { }
 
-		mmap_t(const fd_t &fd, const off_t offset, const std::size_t length, const DWORD prot,
+		mmap_t(const int32_t fd, const off_t offset, const std::size_t length, const DWORD prot,
 			const int32_t = 0, void * = nullptr) noexcept : _len{length},
 			_mapping{[&]() noexcept -> HANDLE
 			{

--- a/substrate/mmap
+++ b/substrate/mmap
@@ -175,11 +175,10 @@ namespace substrate
 
 		SUBSTRATE_NO_DISCARD(SUBSTRATE_CXX14_CONSTEXPR bool valid() const noexcept) { return _addr; }
 #else
-		mmap_t(const int32_t fd, const std::size_t len, const DWORD prot, const int32_t = 0,
+		mmap_t(const int32_t fd, const std::size_t len, const int32_t prot, const int32_t = 0,
 			void * = nullptr) noexcept : _len{len}, _mapping{[&]() noexcept -> HANDLE
 			{
-				const auto file = reinterpret_cast<HANDLE>(_get_osfhandle(fd));
-				static_assert(sizeof(DWORD) == 4);
+				auto *const file{reinterpret_cast<HANDLE>(_get_osfhandle(fd))};
 				return CreateFileMappingA(file, nullptr, cleanProt(prot), DWORD(len >> 32U),
 					DWORD(len), nullptr);
 			}()}, _addr{[&]() noexcept -> void *
@@ -193,8 +192,7 @@ namespace substrate
 			const int32_t = 0, void * = nullptr) noexcept : _len{length},
 			_mapping{[&]() noexcept -> HANDLE
 			{
-				const auto file = reinterpret_cast<HANDLE>(_get_osfhandle(fd));
-				static_assert(sizeof(DWORD) == 4);
+				auto *const file{reinterpret_cast<HANDLE>(_get_osfhandle(fd))};
 #if 0
 				return CreateFileMappingA(file, nullptr, cleanProt(prot), DWORD(length >> 32U),
 					DWORD(length), nullptr);
@@ -208,7 +206,7 @@ namespace substrate
 #if 0
 				return MapViewOfFile(_mapping, protToAccess(prot), DWORD(offset >> 32U), DWORD(offset), 0);
 #else
-				if (DWORD(length >> 32U))
+				if (length > std::numeric_limits<uint32_t>::max())
 					return nullptr;
 				return MapViewOfFile(_mapping, protToAccess(prot), DWORD(offset >> 32U), DWORD(offset), SIZE_T(length));
 #endif

--- a/substrate/mmap
+++ b/substrate/mmap
@@ -224,6 +224,8 @@ namespace substrate
 #endif
 		mmap_t(const mmap_t &) = delete;
 		mmap_t &operator =(const mmap_t &) = delete;
+		mmap_t(mmap_t &&) noexcept = default;
+		mmap_t& operator=(mmap_t &&) noexcept = default;
 
 		void swap(mmap_t &map) noexcept
 		{

--- a/substrate/mmap
+++ b/substrate/mmap
@@ -291,7 +291,8 @@ namespace substrate
 			return unlock(reinterpret_cast<void *>(addr + idx), length);
 		}
 
-#ifndef __APPLE__
+// TODO: implement remap as unmap + map in these platforms
+#if !defined(__APPLE__) && !defined(_WIN32)
 		SUBSTRATE_NO_DISCARD(bool remap(const int32_t flags, const std::size_t new_length) noexcept)
 		{
 			const auto old_len = _len;

--- a/substrate/mmap
+++ b/substrate/mmap
@@ -48,12 +48,14 @@ namespace substrate
 		void *_addr{nullptr};
 		int32_t _fd{-1};
 
+#ifndef _WINDOWS
 		mmap_t(const mmap_t &map, const std::size_t len, const int32_t prot, const int32_t flags = MAP_SHARED,
 			void *addr = nullptr) noexcept : _len{len}, _addr{[&]() noexcept -> void *
 			{
 				const auto ptr = ::mmap(addr, len, prot, flags, map._fd, 0);
 				return ptr == MAP_FAILED ? nullptr : ptr;
 			}()}, _fd{-1} { }
+#endif
 
 		template<typename T> substrate::enable_if_t<substrate::is_pod<T>::value && !has_nullable_ctor<T>::value &&
 			!std::is_same<T, void*>::value, T *> index(const std::size_t idx) const

--- a/substrate/mmap
+++ b/substrate/mmap
@@ -4,10 +4,7 @@
 
 #include <cstdint>
 #include <substrate/internal/defs>
-#ifndef _WINDOWS
-#	include <unistd.h>
-#	include <sys/mman.h>
-#else
+#ifdef _WIN32
 #	ifndef NOMINMAX
 #		define NOMINMAX
 #	endif
@@ -16,6 +13,9 @@
 #	endif
 #	include <io.h>
 #	include <windows.h>
+#else
+#	include <unistd.h>
+#	include <sys/mman.h>
 #endif
 #include <stdexcept>
 #include <cstring>
@@ -28,10 +28,7 @@
 
 namespace substrate
 {
-#ifdef _WINDOWS
-	const DWORD PROT_READ{PAGE_READONLY};
-	const DWORD PROT_WRITE{PAGE_READWRITE};
-	const int32_t MAP_PRIVATE{0};
+#ifdef _WIN32
 
 	const auto MADV_SEQUENTIAL{0};
 	const auto MADV_WILLNEED{0};
@@ -42,13 +39,13 @@ namespace substrate
 	{
 	private:
 		std::size_t _len{0};
-#ifdef _WINDOWS
+#ifdef _WIN32
 		HANDLE _mapping{INVALID_HANDLE_VALUE};
 #endif
 		void *_addr{nullptr};
 		int32_t _fd{-1};
 
-#ifndef _WINDOWS
+#ifdef _WIN32
 		mmap_t(const mmap_t &map, const std::size_t len, const int32_t prot, const int32_t flags = MAP_SHARED,
 			void *addr = nullptr) noexcept : _len{len}, _addr{[&]() noexcept -> void *
 			{
@@ -97,7 +94,7 @@ namespace substrate
 			throw std::out_of_range("mmap_t index out of range");
 		}
 
-#ifdef _WINDOWS
+#ifdef _WIN32
 		SUBSTRATE_CXX14_CONSTEXPR static DWORD cleanProt(const DWORD prot) noexcept
 		{
 			if (prot & PAGE_READWRITE)
@@ -119,7 +116,7 @@ namespace substrate
 
 	public:
 		constexpr mmap_t() noexcept = default;
-#ifndef _WINDOWS
+#ifndef _WIN32
 		mmap_t(const int32_t fd, const std::size_t len, const int32_t prot, const int32_t flags = MAP_SHARED,
 			void *addr = nullptr) noexcept : _len{len}, _addr{[&]() noexcept -> void *
 			{
@@ -195,7 +192,7 @@ namespace substrate
 		{
 			std::swap(_fd, map._fd);
 			std::swap(_addr, map._addr);
-#ifdef _WINDOWS
+#ifdef _WIN32
 			std::swap(_mapping, map._mapping);
 #endif
 			std::swap(_len, map._len);
@@ -274,7 +271,7 @@ namespace substrate
 		}
 #endif
 
-#ifndef _WINDOWS
+#ifndef _WIN32
 		SUBSTRATE_NO_DISCARD(bool sync(const int flags = MS_SYNC | MS_INVALIDATE) const noexcept)
 			{ return sync(_len, flags); }
 

--- a/substrate/mmap
+++ b/substrate/mmap
@@ -116,19 +116,15 @@ namespace substrate
 #ifdef _WIN32
 		SUBSTRATE_CXX14_CONSTEXPR static DWORD cleanProt(const DWORD prot) noexcept
 		{
-			if (prot & PAGE_READWRITE)
-				return prot & ~PAGE_READONLY;
-			return prot;
+			return (prot & PAGE_READWRITE) ? prot & ~PAGE_READONLY : prot;
 		}
 
 		SUBSTRATE_CXX14_CONSTEXPR static DWORD protToAccess(const DWORD prot) noexcept
 		{
-			if (prot & PAGE_READWRITE)
+			if ((prot & PAGE_READWRITE) || (prot & PAGE_WRITECOPY))
 				return FILE_MAP_WRITE;
 			else if (prot & PAGE_READONLY)
 				return FILE_MAP_READ;
-			else if (prot & PAGE_WRITECOPY)
-				return FILE_MAP_WRITE;
 			return {};
 		}
 #endif

--- a/substrate/mmap
+++ b/substrate/mmap
@@ -129,6 +129,30 @@ namespace substrate
 		}
 #endif
 
+		SUBSTRATE_NO_DISCARD(static inline bool lock(void *_addr, const std::size_t length) noexcept)
+#ifdef _WIN32
+			{ return VirtualLock(_addr, length); }
+#else
+			{ return ::mlock(_addr, length) == 0; }
+#endif
+
+		SUBSTRATE_NO_DISCARD(static inline bool unlock(void *_addr, const std::size_t length) noexcept)
+#ifdef _WIN32
+			{ return VirtualUnlock(_addr, length); }
+#else
+			{ return ::munlock(_addr, length) == 0; }
+#endif
+
+		static inline bool unmap(void* _addr, const std::size_t length) noexcept
+		{
+#ifdef _WIN32
+			(void)length;
+			return UnmapViewOfFile(_addr);
+#else
+			return ::munmap(_addr, _len) == 0;
+#endif
+		}
+
 	public:
 		constexpr mmap_t() noexcept = default;
 #ifndef _WIN32
@@ -144,7 +168,7 @@ namespace substrate
 		~mmap_t() noexcept
 		{
 			if (_addr)
-				::munmap(_addr, _len);
+				unmap(_addr);
 			if (_fd != -1)
 				::close(_fd);
 		}
@@ -193,7 +217,7 @@ namespace substrate
 		~mmap_t() noexcept
 		{
 			if (_addr)
-				UnmapViewOfFile(_addr);
+				unmap(_addr, _len);
 			if (_mapping)
 				CloseHandle(_mapping);
 		}
@@ -241,27 +265,27 @@ namespace substrate
 			{ return reinterpret_cast<std::uintptr_t>(_addr); } // lgtm[cpp/reinterpret-cast]
 
 		SUBSTRATE_NO_DISCARD(bool lock() const noexcept)
-			{ return lock(_len); }
+			{ return lock(_addr, _len); }
 		SUBSTRATE_NO_DISCARD(bool lock(const std::size_t length) const noexcept)
-			{ return ::mlock(_addr, length) == 0; }
+			{ return lock(_addr, length); }
 		SUBSTRATE_NO_DISCARD(bool lock_at(const std::size_t idx, const size_t length) const noexcept)
 		{
 			// NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-			const auto addr = reinterpret_cast<std::uintptr_t>(_addr); // lgtm[cpp/reinterpret-cast]
+			const auto addr{reinterpret_cast<std::uintptr_t>(_addr)};
 			// NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-			return ::mlock(reinterpret_cast<void *>(addr + idx), length) == 0; // lgtm[cpp/reinterpret-cast]
+			return lock(reinterpret_cast<void *>(addr + idx), length);
 		}
 
 		SUBSTRATE_NO_DISCARD(bool unlock() const noexcept)
 			{ return unlock(_len); }
 		SUBSTRATE_NO_DISCARD(bool unlock(const std::size_t length) const noexcept)
-			{ return ::munlock(_addr, length) == 0; }
+			{ return unlock(_addr, length); }
 		SUBSTRATE_NO_DISCARD(bool unlock_at(const std::size_t idx, const std::size_t length) const noexcept)
 		{
 			// NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-			const auto addr = reinterpret_cast<std::uintptr_t>(_addr); // lgtm[cpp/reinterpret-cast]
+			const auto addr{reinterpret_cast<std::uintptr_t>(_addr)};
 			// NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-			return ::munlock(reinterpret_cast<void *>(addr + idx), length) == 0; // lgtm[cpp/reinterpret-cast]
+			return unlock(reinterpret_cast<void *>(addr + idx), length);
 		}
 
 #ifndef __APPLE__

--- a/substrate/mmap
+++ b/substrate/mmap
@@ -8,8 +8,12 @@
 #	include <unistd.h>
 #	include <sys/mman.h>
 #else
-#	define NOMINMAX
-#	define WIN32_LEAN_AND_MEAN
+#	ifndef NOMINMAX
+#		define NOMINMAX
+#	endif
+#	ifndef WIN32_LEAN_AND_MEAN
+#		define WIN32_LEAN_AND_MEAN
+#	endif
 #	include <io.h>
 #	include <windows.h>
 #endif

--- a/substrate/mmap
+++ b/substrate/mmap
@@ -51,6 +51,20 @@ namespace substrate
 		int32_t _fd{-1};
 
 #ifdef _WIN32
+		mmap_t(const mmap_t &map, const std::size_t len, const int32_t prot, const int32_t = 0,
+		void * = nullptr) noexcept : _len{len}, _mapping{[&]() noexcept -> HANDLE
+		{
+			// NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast,performance-no-int-to-ptr)
+			auto *const file{reinterpret_cast<HANDLE>(_get_osfhandle(map._fd))};
+			return CreateFileMappingA(file, nullptr, cleanProt(prot), DWORD(len >> 32U),
+				DWORD(len), nullptr);
+		}()}, _addr{[&]() noexcept -> void *
+		{
+			if (!_mapping)
+				return nullptr;
+			return MapViewOfFile(_mapping, protToAccess(prot), 0, 0, 0);
+		}()} { }
+#else
 		mmap_t(const mmap_t &map, const std::size_t len, const int32_t prot, const int32_t flags = MAP_SHARED,
 			void *addr = nullptr) noexcept : _len{len}, _addr{[&]() noexcept -> void *
 			{

--- a/substrate/mmap
+++ b/substrate/mmap
@@ -245,7 +245,12 @@ namespace substrate
 			return {*this, len, prot, flags, addr};
 		}
 
-		SUBSTRATE_NO_DISCARD(bool chperm(const int32_t prot) noexcept) { return mprotect(_addr, _len, prot) == 0; }
+		SUBSTRATE_NO_DISCARD(bool chperm(const int32_t prot) noexcept)
+#ifdef _WIN32
+			{ return VirtualProtect(_addr, _len, prot, nullptr) == 0; }
+#else
+			{ return mprotect(_addr, _len, prot) == 0; }
+#endif
 
 		template<typename T> T *address() noexcept { return static_cast<T *>(_addr); }
 		template<typename T> const T *address() const noexcept { return static_cast<const T *>(_addr); }

--- a/test/mmap.cxx
+++ b/test/mmap.cxx
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
+#include <cstdio>
 #include <substrate/mmap>
 #include <substrate/memfd>
 #include <substrate/fd>
@@ -103,7 +104,6 @@ TEST_CASE("Structure serialization and loading", "[mmap_t]")
 		// REQUIRE(std::memcmp(_d, &d, sizeof(foo)) == 0);
 	}
 
-
-
+	static_cast<void>(remove("mmap_t.serialized"));
 }
 /* vim: set ft=cpp ts=4 sw=4 noexpandtab: */


### PR DESCRIPTION
This PR seeks to address issues discovered in mmap_t when built for and attempted to be used on Windows.

With the excellent help of @amyspark this brings the type to almost perfect feature parity with the *nix version and irons out compilation and use via either MSVC or MSYS2.