### PR TITLE
ci: Optimize job matrix and fix some Meson warnings

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - 'main'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.job }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze-cpp:
     name: Analyse C++

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -222,7 +222,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   build-windows-mingw:
-    name: '${{ matrix.os }} (${{ matrix.sys.abi }}, ${{ matrix.cpp_std }})'
+    name: '${{ matrix.os }} (${{ matrix.sys }}, ${{ matrix.cpp_std }})'
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -232,9 +232,9 @@ jobs:
         os:
           - windows-2019
         sys:
-          - { abi: mingw64, env: x86_64,       compiler: gcc }
-          - { abi: ucrt64,  env: ucrt-x86_64,  compiler: gcc }
-          - { abi: clang64, env: clang-x86_64, compiler: clang }
+          - mingw64
+          - ucrt64
+          - clang64
         cpp_std:
           - 'c++11'
           - 'c++14'
@@ -245,11 +245,12 @@ jobs:
       - name: Use MinGW from MSYS
         uses: msys2/setup-msys2@v2
         with:
-          msystem: ${{matrix.sys.abi}}
+          msystem: ${{ matrix.sys }}
           update: true
           path-type: inherit
-          install: >-
-            mingw-w64-${{matrix.sys.env}}-toolchain
+          pacboy: >-
+            toolchain:p
+            lcov:p
       - name: Runtime environment
         env:
           WORKSPACE: ${{ github.workspace }}
@@ -257,23 +258,13 @@ jobs:
           echo "$HOME/.local/bin" >> $GITHUB_PATH
           echo "GITHUB_WORKSPACE=`pwd`" >> $GITHUB_ENV
       - name: Setup compiler
-        if: startsWith(matrix.sys.abi, 'mingw64') || startsWith(matrix.sys.abi, 'ucrt64')
+        if: startsWith(matrix.sys, 'mingw') || startsWith(matrix.sys, 'ucrt64')
         run: |
-          CXX=${CC/#gcc/g++}
-          echo "CC=$CC" >> $GITHUB_ENV
-          echo "CXX=$CXX" >> $GITHUB_ENV
           echo "GCOV=gcov" >> $GITHUB_ENV
-        env:
-          CC: ${{ matrix.sys.compiler }}
       - name: Setup compiler
-        if: startsWith(matrix.sys.abi, 'clang64')
+        if: startsWith(matrix.sys, 'clang')
         run: |
-          CXX=${CC/#clang/clang++}
-          echo "CC=$CC" >> $GITHUB_ENV
-          echo "CXX=$CXX" >> $GITHUB_ENV
           echo "GCOV=llvm-cov gcov" >> $GITHUB_ENV
-        env:
-          CC: ${{ matrix.sys.compiler }}
       - name: Checkout
         uses: actions/checkout@v3
         with:
@@ -287,8 +278,8 @@ jobs:
         working-directory: ${{ runner.temp }}
       - name: Version tools
         run: |
-          $CC --version
-          $CXX --version
+          cc --version
+          c++ --version
           $GCOV --version
           meson --version
           ninja --version
@@ -314,7 +305,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v3
         with:
-          name: logs-${{ matrix.os }}-${{ matrix.sys.abi }}-${{ matrix.cpp_std }}
+          name: logs-${{ matrix.os }}-${{ matrix.sys }}-${{ matrix.cpp_std }}
           path: ${{ github.workspace }}/build/meson-logs/*
           retention-days: 5
       - name: Codecov

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -37,16 +37,16 @@ jobs:
           - 'gcc-10'
           - 'gcc-11'
         cpp_std:
-          - 'c++11'
-          - 'c++14'
-          - 'c++17'
+          - 11
+          - 14
+          - 17
         include:
           - os: { id: ubuntu-20.04, name: focal }
             compiler: 'clang-15'
-            cpp_std: 'c++20'
+            cpp_std: 20
           - os: { id: ubuntu-20.04, name: focal }
             compiler: 'gcc-11'
-            cpp_std: 'c++20'
+            cpp_std: 20
       fail-fast: false
     steps:
       - name: Runtime environment
@@ -108,19 +108,20 @@ jobs:
           meson --version
           ninja --version
       - name: Configure
-        run: meson setup build --prefix=$HOME/.local -Dcpp_std=${{ matrix.cpp_std }} $BUILD_OPTS
+        run: meson setup build --prefix=$HOME/.local -Dcpp_std=c++${{ matrix.cpp_std }} $BUILD_OPTS
       - name: Build
         run: meson compile -C build
       - name: Test
+        if: matrix.cpp_std > 11
         run: meson test -C build
       - name: Install
         run: meson install -C build 
       - name: Run coverage build
-        if: github.repository == 'bad-alloc-heavy-industries/substrate'
+        if: github.repository == 'bad-alloc-heavy-industries/substrate' && matrix.cpp_std > 11
         # Codecov no longer parses gcov files automatically
         run: |
           rm -rf build
-          meson setup build --prefix=$HOME/.local -Dcpp_std=${{ matrix.cpp_std }} -Db_coverage=true --buildtype=debug
+          meson setup build --prefix=$HOME/.local -Dcpp_std=c++${{ matrix.cpp_std }} -Db_coverage=true --buildtype=debug
           meson compile -C build
           meson test -C build
           cd build
@@ -134,7 +135,7 @@ jobs:
           path: ${{ github.workspace }}/build/meson-logs/*
           retention-days: 5
       - name: Codecov
-        if: success() && github.repository == 'bad-alloc-heavy-industries/substrate'
+        if: success() && github.repository == 'bad-alloc-heavy-industries/substrate' && matrix.cpp_std > 11
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -151,11 +152,11 @@ jobs:
           - windows-2019
           - windows-2022
         cpp_std:
-          - 'c++14'
-          - 'c++17'
+          - 14
+          - 17
         include:
           - os: windows-2022
-            cpp_std: 'c++20'
+            cpp_std: 20
       fail-fast: false
     steps:
       - name: Runtime environment
@@ -174,7 +175,7 @@ jobs:
         with:
           args: install OpenCppCoverage
       - name: Setup OpenCppCoverage
-        if: github.repository == 'bad-alloc-heavy-industries/substrate'
+        if: github.repository == 'bad-alloc-heavy-industries/substrate' && matrix.cpp_std > 11
         run: |
           echo "C:\Program Files\OpenCppCoverage" >> $GITHUB_PATH
       - name: Checkout
@@ -194,18 +195,19 @@ jobs:
           meson --version
           ninja --version
       - name: Configure
-        run: meson setup build --prefix=$HOME/.local -Dcpp_std=${{ matrix.cpp_std }} $BUILD_OPTS
+        run: meson setup build --prefix=$HOME/.local -Dcpp_std=c++${{ matrix.cpp_std }} $BUILD_OPTS
       - name: Build
         run: meson compile -C build
       - name: Test
+        if: matrix.cpp_std > 11
         run: meson test -C build
       - name: Install
         run: meson install -C build
       - name: Run coverage build
-        if: github.repository == 'bad-alloc-heavy-industries/substrate'
+        if: github.repository == 'bad-alloc-heavy-industries/substrate' && matrix.cpp_std > 11
         run: |
           Remove-Item -Recurse build
-          meson setup build --prefix=$HOME/.local -Dcpp_std=${{ matrix.cpp_std }} -Db_coverage=true --buildtype=debug
+          meson setup build --prefix=$HOME/.local -Dcpp_std=c++${{ matrix.cpp_std }} -Db_coverage=true --buildtype=debug
           meson compile -C build
           meson test -C build
       - name: Upload failure logs
@@ -216,7 +218,7 @@ jobs:
           path: ${{ github.workspace }}/build/meson-logs/*
           retention-days: 5
       - name: Codecov
-        if: success() && github.repository == 'bad-alloc-heavy-industries/substrate'
+        if: success() && github.repository == 'bad-alloc-heavy-industries/substrate' && matrix.cpp_std > 11
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -236,10 +238,10 @@ jobs:
           - ucrt64
           - clang64
         cpp_std:
-          - 'c++11'
-          - 'c++14'
-          - 'c++17'
-          - 'c++20'
+          - 11
+          - 14
+          - 17
+          - 20
       fail-fast: false
     steps:
       - name: Use MinGW from MSYS
@@ -284,19 +286,20 @@ jobs:
           meson --version
           ninja --version
       - name: Configure
-        run: meson setup build --prefix=$HOME/.local -Dcpp_std=${{ matrix.cpp_std }} $BUILD_OPTS
+        run: meson setup build --prefix=$HOME/.local -Dcpp_std=c++${{ matrix.cpp_std }} $BUILD_OPTS
       - name: Build
         run: meson compile -C build
       - name: Test
+        if: matrix.cpp_std > 11
         run: meson test -C build
       - name: Install
         run: ninja -C build install
       - name: Run coverage build
-        if: github.repository == 'bad-alloc-heavy-industries/substrate'
+        if: github.repository == 'bad-alloc-heavy-industries/substrate' && matrix.cpp_std > 11
         # Codecov no longer parses gcov files automatically
         run: |
           rm -rf build
-          meson setup build --prefix=$HOME/.local -Dcpp_std=${{ matrix.cpp_std }} -Db_coverage=true --buildtype=debug
+          meson setup build --prefix=$HOME/.local -Dcpp_std=c++${{ matrix.cpp_std }} -Db_coverage=true --buildtype=debug
           meson compile -C build
           meson test -C build
           cd build
@@ -309,7 +312,7 @@ jobs:
           path: ${{ github.workspace }}/build/meson-logs/*
           retention-days: 5
       - name: Codecov
-        if: success() && github.repository == 'bad-alloc-heavy-industries/substrate'
+        if: success() && github.repository == 'bad-alloc-heavy-industries/substrate' && matrix.cpp_std > 11
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -326,9 +329,9 @@ jobs:
           - macos-12
           - macos-11
         cpp_std:
-          - 'c++11'
-          - 'c++14'
-          - 'c++17'
+          - 11
+          - 14
+          - 17
       fail-fast: false
     steps:
       - name: Runtime environment
@@ -357,19 +360,20 @@ jobs:
           meson --version
           ninja --version
       - name: Configure
-        run: meson setup build --prefix=$HOME/.local -Db_coverage=true -Dcpp_std=${{ matrix.cpp_std }} $BUILD_OPTS
+        run: meson setup build --prefix=$HOME/.local -Db_coverage=true -Dcpp_std=c++${{ matrix.cpp_std }} $BUILD_OPTS
       - name: Build
         run: meson compile -C build
       - name: Test
+        if: matrix.cpp_std > 11
         run: meson test -C build
       - name: Install
         run: ninja -C build install
       - name: Run coverage build
-        if: github.repository == 'bad-alloc-heavy-industries/substrate'
+        if: github.repository == 'bad-alloc-heavy-industries/substrate' && matrix.cpp_std > 11
         # Codecov no longer parses gcov files automatically
         run: |
           rm -rf build
-          meson setup build --prefix=$HOME/.local -Dcpp_std=${{ matrix.cpp_std }} -Db_coverage=true --buildtype=debug
+          meson setup build --prefix=$HOME/.local -Dcpp_std=c++${{ matrix.cpp_std }} -Db_coverage=true --buildtype=debug
           meson compile -C build
           meson test -C build
           cd build
@@ -382,7 +386,7 @@ jobs:
           path: ${{ github.workspace }}/build/meson-logs/*
           retention-days: 5
       - name: Codecov
-        if: success() && github.repository == 'bad-alloc-heavy-industries/substrate'
+        if: success() && github.repository == 'bad-alloc-heavy-industries/substrate' && matrix.cpp_std > 11
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -413,13 +417,13 @@ jobs:
           - gcc@11
           - gcc
         cpp_std:
-          - 'c++11'
-          - 'c++14'
-          - 'c++17'
+          - 11
+          - 14
+          - 17
         include:
           - os: macos-11
             compiler: gcc
-            cpp_std: 'c++20'
+            cpp_std: 20
       fail-fast: false
     steps:
       - name: Runtime environment
@@ -455,19 +459,20 @@ jobs:
           meson --version
           ninja --version
       - name: Configure
-        run: meson setup build --prefix=$HOME/.local -Dcpp_std=${{ matrix.cpp_std }} $BUILD_OPTS
+        run: meson setup build --prefix=$HOME/.local -Dcpp_std=c++${{ matrix.cpp_std }} $BUILD_OPTS
       - name: Build
         run: meson compile -C build
       - name: Test
+        if: matrix.cpp_std > 11
         run: meson test -C build
       - name: Install
         run: ninja -C build install
       - name: Run coverage build
-        if: github.repository == 'bad-alloc-heavy-industries/substrate'
+        if: github.repository == 'bad-alloc-heavy-industries/substrate' && matrix.cpp_std > 11
         # Codecov no longer parses gcov files automatically
         run: |
           rm -rf build
-          meson setup build --prefix=$HOME/.local -Dcpp_std=${{ matrix.cpp_std }} -Db_coverage=true --buildtype=debug
+          meson setup build --prefix=$HOME/.local -Dcpp_std=c++${{ matrix.cpp_std }} -Db_coverage=true --buildtype=debug
           meson compile -C build
           meson test -C build
           cd build
@@ -480,7 +485,7 @@ jobs:
           path: ${{ github.workspace }}/build/meson-logs/*
           retention-days: 5
       - name: Codecov
-        if: success() && github.repository == 'bad-alloc-heavy-industries/substrate'
+        if: success() && github.repository == 'bad-alloc-heavy-industries/substrate' && matrix.cpp_std > 11
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Hi @dragonmux,

There were some bits about the current CI output that were bothering me:

- we duplicated ABI checks a Lot in MSYS2
- CodeQL has no concurrency barrier in case of force pushes
- Meson complains that there's no lcov executable installed when generating the coverage report
- Codecov complains in turn because the C++11 coverage builds don't upload anything (thanks catch2! It needs C++14 minimum)

This PR attempts to fix all of them at once. I've not checked if they work due to the origin check in them, so 🤞 
