### PR TITLE
Fix MSVC and Linux coverage

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -61,7 +61,7 @@ jobs:
           CXX=${CC/#gcc/g++}
           sudo apt-add-repository ppa:ubuntu-toolchain-r/test
           sudo apt-get update
-          sudo apt-get install $CC $CXX gcovr
+          sudo apt-get install $CC $CXX
           echo "CC=$CC" >> $GITHUB_ENV
           echo "CXX=$CXX" >> $GITHUB_ENV
           echo "GCOV=${CC/#gcc/gcov}" >> $GITHUB_ENV
@@ -75,7 +75,7 @@ jobs:
           rm llvm-snapshot.gpg.key
           sudo apt-add-repository "deb https://apt.llvm.org/${{ matrix.os.name }}/ llvm-toolchain-${{ matrix.os.name }}${CC/#clang/} main"
           sudo apt-get update
-          sudo apt-get install $CC gcovr
+          sudo apt-get install $CC
           CXX=${CC/#clang/clang++}
           echo "CC=$CC" >> $GITHUB_ENV
           echo "CXX=$CXX" >> $GITHUB_ENV
@@ -95,10 +95,10 @@ jobs:
         with:
           lfs: true
           submodules: true
-      - name: Setup Meson + Ninja
+      - name: Setup Meson + Ninja + gcovr
         run: |
           sudo python3 -m pip install --upgrade pip setuptools wheel
-          sudo python3 -m pip install meson ninja
+          sudo python3 -m pip install meson ninja gcovr
         working-directory: ${{ runner.temp }}
       - name: Version tools
         run: |

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -177,7 +177,7 @@ jobs:
       - name: Setup OpenCppCoverage
         if: github.repository == 'bad-alloc-heavy-industries/substrate' && matrix.cpp_std > 11
         run: |
-          echo "C:\Program Files\OpenCppCoverage" >> $GITHUB_PATH
+          echo "C:/Program Files/OpenCppCoverage" >> $env:GITHUB_PATH
       - name: Checkout
         uses: actions/checkout@v3
         with:

--- a/meson.build
+++ b/meson.build
@@ -104,20 +104,18 @@ if isWindows
 	# if MSVC, b_coverage will always return false because
 	# Meson doesn't officially support coverage
 	if cxx.get_id() == 'msvc' and get_option('buildtype') == 'debug'
-		coverageRunner = find_program('OpenCppCoverage', required: false)
+		coverageRunner = find_program('OpenCppCoverage', required: true)
 
-		if coverageRunner.found()
-			message('Enabling coverage under MSVC')
-			coverageArgs = [
-				'--sources', '@0@\\impl\\*'.format(meson.current_source_dir()),
-				'--sources', '@0@\\substrate\\*'.format(meson.current_source_dir()),
-				'--sources', '@0@\\test\\*'.format(meson.current_source_dir()),
-				'--sources', '@0@\\*'.format(meson.current_build_dir()),
-				'--modules', meson.current_build_dir(),
-				'--export_type'
-			]
-			coverage = true
-		endif
+		message('Enabling coverage under MSVC')
+		coverageArgs = [
+			'--sources', '@0@\\impl\\*'.format(meson.current_source_dir()),
+			'--sources', '@0@\\substrate\\*'.format(meson.current_source_dir()),
+			'--sources', '@0@\\test\\*'.format(meson.current_source_dir()),
+			'--sources', '@0@\\*'.format(meson.current_build_dir()),
+			'--modules', meson.current_build_dir(),
+			'--export_type'
+		]
+		coverage = true
 	endif
 endif
 


### PR DESCRIPTION
Hi @dragonmux,

I don't know how this was working previously, but both sets' coverage was broken-- MSVC no longer found OpenCppCoverage because we never wrote the path entry to the correct file (`$env:GITHUB_PATH` since it's PowerShell), and Linux in turn had always returned 0% coverage because of a too old gcovr doing *something* when assembling the report.

While just telling gcovr to use the `-g` flag was enough to fix it in my VM, I prefer to use an actually known working version from pip instead.