### PR TITLE
ci: Assorted improvements in MSVC

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -215,7 +215,9 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: logs-${{ matrix.os }}-${{ matrix.cpp_std }}
-          path: ${{ github.workspace }}/build/meson-logs/*
+          path: |
+            ${{ github.workspace }}/build/meson-logs
+            ${{ github.workspace }}/build/test
           retention-days: 5
       - name: Codecov
         if: success() && github.repository == 'bad-alloc-heavy-industries/substrate' && matrix.cpp_std > 11

--- a/meson.build
+++ b/meson.build
@@ -110,7 +110,6 @@ if isWindows
 		coverageArgs = [
 			'--sources', '@0@\\impl\\*'.format(meson.current_source_dir()),
 			'--sources', '@0@\\substrate\\*'.format(meson.current_source_dir()),
-			'--sources', '@0@\\test\\*'.format(meson.current_source_dir()),
 			'--sources', '@0@\\*'.format(meson.current_build_dir()),
 			'--modules', meson.current_build_dir(),
 			'--export_type'


### PR DESCRIPTION
Hi @dragonmux,

This PR fixes the following nitpicks with regards to the MSVC jobs:

- they still submitted coverage for the test folder, which we already exclude in the rest of the jobs.
- for the cases where they time out (codegen or deadlock issues?) we'll now submit the test executables and PDB as well, for local testing.

Let me know what you think.