### PR TITLE
Fix: command_line review items & Coverity lints

### DIFF
--- a/impl/command_line/arguments.cxx
+++ b/impl/command_line/arguments.cxx
@@ -17,6 +17,8 @@ namespace substrate::commandLine
 
 	static bool operator <(const optionsItem_t &lhs, const optionsItem_t &rhs) noexcept
 	{
+		if (lhs.valueless_by_exception() || rhs.valueless_by_exception())
+			return false;
 		// First, if the alternative held is numerically < then sort on that
 		if (lhs.index() < rhs.index())
 			return true;
@@ -43,6 +45,8 @@ namespace substrate::commandLine
 
 	static bool operator <(const item_t &lhs, const item_t &rhs) noexcept
 	{
+		if (lhs.valueless_by_exception() || rhs.valueless_by_exception())
+			return false;
 		// First extract the item name values
 		const auto lhsName{itemName(lhs)};
 		const auto rhsName{itemName(rhs)};
@@ -52,12 +56,16 @@ namespace substrate::commandLine
 
 	static bool operator <(const item_t &lhs, const std::string_view &rhsName) noexcept
 	{
+		if (lhs.valueless_by_exception())
+			return false;
 		const auto lhsName{itemName(lhs)};
 		return lhsName < rhsName;
 	}
 
 	static bool operator <(const std::string_view &lhsName, const item_t &rhs) noexcept
 	{
+		if (rhs.valueless_by_exception())
+			return false;
 		const auto rhsName{itemName(rhs)};
 		return lhsName < rhsName;
 	}
@@ -97,7 +105,8 @@ namespace substrate::commandLine
 		size_t valueOptions{};
 		for (const auto &option : options)
 		{
-			if (!std::visit(match_t
+			if (option.valueless_by_exception() ||
+				!std::visit(match_t
 				{
 					[&](const option_t &value)
 					{
@@ -121,6 +130,9 @@ namespace substrate::commandLine
 		std::set<internal::optionsItem_t> requiredOptions{};
 		for (const auto &option : options)
 		{
+			// If the optionItem_t is a bad variant, ignore it
+			if (option.valueless_by_exception())
+				continue;
 			std::visit(match_t
 			{
 				// If it's an option_t, and it's required, then add it to the set

--- a/impl/command_line/arguments.cxx
+++ b/impl/command_line/arguments.cxx
@@ -6,6 +6,7 @@
 #include <substrate/command_line/arguments>
 #include <substrate/command_line/tokeniser>
 
+using namespace std::literals::string_literals;
 using namespace std::literals::string_view_literals;
 
 namespace substrate::commandLine
@@ -150,6 +151,8 @@ namespace substrate::commandLine
 
 	static auto displayName(const optionsItem_t &item)
 	{
+		if (item.valueless_by_exception())
+			return ""s;
 		return std::visit(match_t
 		{
 			[](const option_t &option) { return option.displayName(); },
@@ -433,8 +436,10 @@ namespace substrate::commandLine
 
 	bool operator ==(const item_t &lhs, const item_t &rhs) noexcept
 	{
-		// Check if the items hold the same type, if not they can't be equal
-		if (lhs.index() != rhs.index())
+		// If either is valueless, treat as unequal
+		if (lhs.valueless_by_exception() || rhs.valueless_by_exception() ||
+			// Check if the items hold the same type, if not they can't be equal
+			lhs.index() != rhs.index())
 			return false;
 		// Now convert them to their underlying type and compare those
 		if (std::holds_alternative<flag_t>(lhs))

--- a/impl/command_line/arguments.cxx
+++ b/impl/command_line/arguments.cxx
@@ -367,22 +367,23 @@ namespace substrate::commandLine
 	static void handleUnrecognised(tokeniser_t &lexer, const std::string_view &argument)
 	{
 		const auto &token{lexer.next()};
-		// If the argument is followed by an '=', grab both parts of it for display
-		if (token.type() == tokenType_t::equals)
+		// If the argument stands alone, display it and fast exit
+		if (token.type() != tokenType_t::equals)
 		{
-			lexer.next();
-			// If there's nothing after the '=', display what we've got
-			if (token.type() == tokenType_t::space)
-				console.error("Unrecognised command line argument '"sv, argument, "='"sv);
-			else
-			{
-				const auto value{token.value()};
-				console.error("Unrecognised command line argument '"sv, argument, '=', value, "'"sv);
-				lexer.next();
-			}
-		}
-		else
 			console.error("Unrecognised command line argument '"sv, argument, "'"sv);
+			return;
+		}
+		// If the argument is followed by an '=', grab both parts of it for display
+		lexer.next();
+		// If there's nothing after the '=', display what we've got
+		if (token.type() == tokenType_t::space)
+			console.error("Unrecognised command line argument '"sv, argument, "='"sv);
+		else
+		{
+			const auto value{token.value()};
+			console.error("Unrecognised command line argument '"sv, argument, '=', value, "'"sv);
+			lexer.next();
+		}
 	}
 
 	// Implementation of the innards of arguments_t as otherwise we get compile errors

--- a/impl/command_line/arguments.cxx
+++ b/impl/command_line/arguments.cxx
@@ -296,20 +296,19 @@ namespace substrate::commandLine
 	{
 		// Check if we're parsing an alternation from a set
 		const auto match{option.matches(argument)};
-		if (match)
-		{
-			// Check which alternation matched, recurse and parse all further options from the
-			// alternation's perspective
-			const auto &alternation{match->get()};
-			lexer.next();
-			arguments_t subarguments{};
-			const auto &suboptions{alternation.suboptions()};
-			if (!suboptions.empty() && !subarguments.parseFrom(lexer, suboptions))
-				// If the operation fails, use monostate to signal match-but-fail.
-				return std::monostate{};
-			return choice_t{option.metaName(), argument, std::move(subarguments)};
-		}
-		return std::nullopt;
+		// If that failed, fast-fail
+		if (!match)
+			return std::nullopt;
+		// Check which alternation matched, recurse and parse all further options from the
+		// alternation's perspective
+		const auto &alternation{match->get()};
+		lexer.next();
+		arguments_t subarguments{};
+		const auto &suboptions{alternation.suboptions()};
+		if (!suboptions.empty() && !subarguments.parseFrom(lexer, suboptions))
+			// If the operation fails, use monostate to signal match-but-fail.
+			return std::monostate{};
+		return choice_t{option.metaName(), argument, std::move(subarguments)};
 	}
 
 	template<typename set_t> static bool checkMatchValid(const optionsItem_t &option, set_t &optionsVisited)

--- a/impl/command_line/arguments.cxx
+++ b/impl/command_line/arguments.cxx
@@ -344,7 +344,7 @@ namespace substrate::commandLine
 		return std::visit(match_t
 		{
 			// We got a match and parsing it succeeded?
-			[&]([[maybe_unused]] const auto &result) -> std::optional<bool> { return arguments.add(result); },
+			[&](const auto &result) -> std::optional<bool> { return arguments.add(result); },
 			// Match but inner parsing failed
 			[](std::monostate) -> std::optional<bool> { return std::nullopt; },
 		}, match);

--- a/impl/command_line/options.cxx
+++ b/impl/command_line/options.cxx
@@ -62,7 +62,8 @@ namespace substrate::commandLine
 		// Now do the conversion
 		const auto result{number.fromDec()};
 		// Check if we have a range restriction
-		if (!std::holds_alternative<optionSignedInt_t>(_valueAllowedRange))
+		if (_valueAllowedRange.valueless_by_exception() ||
+			!std::holds_alternative<optionSignedInt_t>(_valueAllowedRange))
 			// Return the result of conversion unchecked if we do not
 			return result;
 		const auto &range{std::get<optionSignedInt_t>(_valueAllowedRange)};
@@ -82,7 +83,8 @@ namespace substrate::commandLine
 		// Now do the conversion
 		const auto result{number.fromDec()};
 		// Check if we have a range restriction
-		if (!std::holds_alternative<optionUnsignedInt_t>(_valueAllowedRange))
+		if (_valueAllowedRange.valueless_by_exception() ||
+			!std::holds_alternative<optionUnsignedInt_t>(_valueAllowedRange))
 			// Return the result of conversion unchecked if we do not
 			return result;
 		const auto &range{std::get<optionUnsignedInt_t>(_valueAllowedRange)};
@@ -146,6 +148,8 @@ namespace substrate::commandLine
 
 	[[nodiscard]] std::string_view option_t::metaName() const noexcept
 	{
+		if (_option.valueless_by_exception())
+			return ""sv;
 		return std::visit(match_t
 		{
 			[](const std::string_view &option) { return unprefix(option); },
@@ -156,6 +160,8 @@ namespace substrate::commandLine
 
 	[[nodiscard]] std::string option_t::displayName() const noexcept
 	{
+		if (_option.valueless_by_exception())
+			return ""s;
 		return std::visit(match_t
 		{
 			[](const std::string_view &option) { return std::string{option}; },

--- a/substrate/command_line/options
+++ b/substrate/command_line/options
@@ -154,6 +154,9 @@ namespace substrate::commandLine
 
 		[[nodiscard]] constexpr bool operator <(const option_t &other) const noexcept
 		{
+			// If either variant holds no value, consider unequal
+			if (_option.valueless_by_exception() || other._option.valueless_by_exception())
+				return false;
 			// Check if the alternative held is numerically <
 			if (_option.index() < other._option.index())
 				return true;

--- a/substrate/enum_utils
+++ b/substrate/enum_utils
@@ -21,19 +21,21 @@ namespace substrate
 
 	template<class T> struct enumPair_t final
 	{
-		using value_type = T;
 	private:
-		T _value;
-		const char* _name;
+		T _value{};
+		const char *_name{};
+
 	public:
-		constexpr enumPair_t() noexcept : _value{}, _name{} { }
+		constexpr enumPair_t() noexcept = default;
 		constexpr enumPair_t(T value, const char* name) noexcept : _value{value}, _name{name} { }
+
+		using value_type = T;
 
 		void value(const T value) noexcept { _value = value; }
 		SUBSTRATE_NO_DISCARD(T value() const noexcept) { return _value; }
 
-		void name(const char* name) noexcept { _name = name; }
-		SUBSTRATE_NO_DISCARD(const char* name() const noexcept) { return _name; }
+		void name(const char *name) noexcept { _name = name; }
+		SUBSTRATE_NO_DISCARD(const char *name() const noexcept) { return _name; }
 	};
 
 	/* Extract a collection of flags set in a field */
@@ -79,8 +81,8 @@ namespace substrate
 		return pos != std::end(map) ? pos->name() : "UNKNOWN";
 	}
 
-	template<class map_t>
-	typename map_t::value_type::value_type enum_value(map_t map, const std::string &name) noexcept
+	template<class map_t> typename map_t::value_type::value_type
+		enum_value(map_t map, const std::string &name) noexcept
 	{
 		auto pos = std::find_if(std::begin(map), std::end(map),
 			[&](const typename map_t::value_type &entry)

--- a/substrate/enum_utils
+++ b/substrate/enum_utils
@@ -43,7 +43,7 @@ namespace substrate
 	{
 		std::vector<T> foundFlags{};
 		using enumInt_t = typename substrate::underlying_type_t<T>;
-		for (auto flag : enumTable)
+		for (const auto &flag : enumTable)
 		{
 			if ((flags & flag.value()) == flag.value() && static_cast<enumInt_t>(flag.value()) != 0)
 				foundFlags.emplace_back(flag.value());
@@ -59,7 +59,7 @@ namespace substrate
 	{
 		std::vector<enumPair_t<T>> foundFlags{};
 		using enumInt_t = typename substrate::underlying_type_t<T>;
-		for (auto flag : enumTable)
+		for (const auto &flag : enumTable)
 		{
 			if ((flags & flag.value()) == flag.value() && static_cast<enumInt_t>(flag.value()) != 0)
 				foundFlags.emplace_back(flag);

--- a/substrate/enum_utils
+++ b/substrate/enum_utils
@@ -39,57 +39,55 @@ namespace substrate
 	/* Extract a collection of flags set in a field */
 	/* This is kind of expensive run-time wise, being at leas O(n+1) but *shrug* */
 	template<typename T, typename A> enable_if_t<std::is_enum<T>::value, std::vector<T>>
-		extract_flags(T flags, A& enum_table)
+		extract_flags(T flags, const A &enumTable)
 	{
-		std::vector<T> _found_flags;
-		using ut = typename substrate::underlying_type_t<T>;
-		for (auto flag : enum_table)
+		std::vector<T> foundFlags{};
+		using enumInt_t = typename substrate::underlying_type_t<T>;
+		for (auto flag : enumTable)
 		{
-			if ((flags & flag.value()) == flag.value() && static_cast<ut>(flag.value()) != 0)
-				_found_flags.emplace_back(flag.value());
+			if ((flags & flag.value()) == flag.value() && static_cast<enumInt_t>(flag.value()) != 0)
+				foundFlags.emplace_back(flag.value());
 		}
 
-		if (_found_flags.empty())
-			_found_flags.emplace_back(T{});
-
-		return _found_flags;
+		if (foundFlags.empty())
+			foundFlags.emplace_back(T{});
+		return foundFlags;
 	}
 
 	template<typename T, typename A> enable_if_t<std::is_enum<T>::value, std::vector<enumPair_t<T>>>
-		extract_flag_pairs(T flags, A& enum_table)
+		extract_flag_pairs(T flags, const A &enumTable)
 	{
-		std::vector<enumPair_t<T>> _found_flags;
-		using ut = typename substrate::underlying_type_t<T>;
-		for (auto flag : enum_table)
+		std::vector<enumPair_t<T>> foundFlags{};
+		using enumInt_t = typename substrate::underlying_type_t<T>;
+		for (auto flag : enumTable)
 		{
-			if((flags & flag.value()) == flag.value() && static_cast<ut>(flag.value()) != 0)
-				_found_flags.emplace_back(flag);
+			if ((flags & flag.value()) == flag.value() && static_cast<enumInt_t>(flag.value()) != 0)
+				foundFlags.emplace_back(flag);
 		}
 
-		if(_found_flags.size() == 0)
-			_found_flags.emplace_back(enum_table[0]);
-
-		return _found_flags;
+		if (foundFlags.size() == 0)
+			foundFlags.emplace_back(enumTable[0]);
+		return foundFlags;
 	}
 
-	template<class map_t, class value_t> std::string enum_name(map_t m, value_t v) noexcept
+	template<class map_t, class value_t> std::string enum_name(map_t map, value_t value) noexcept
 	{
-		auto pos = std::find_if(std::begin(m), std::end(m),
-			[&v](const typename map_t::value_type& t)
-				{ return (t.value() == v); }
+		auto pos = std::find_if(std::begin(map), std::end(map),
+			[&](const typename map_t::value_type &entry)
+				{ return (entry.value() == value); }
 		);
-		return pos != std::end(m) ? pos->name() : "UNKNOWN";
+		return pos != std::end(map) ? pos->name() : "UNKNOWN";
 	}
 
 	template<class map_t>
-	typename map_t::value_type::value_type enum_value(map_t m, const std::string& n) noexcept
+	typename map_t::value_type::value_type enum_value(map_t map, const std::string &name) noexcept
 	{
-		auto pos = std::find_if(std::begin(m), std::end(m),
-			[&n](const typename map_t::value_type& t)
-				{ return (t.name() == n); }
+		auto pos = std::find_if(std::begin(map), std::end(map),
+			[&](const typename map_t::value_type &entry)
+				{ return (entry.name() == name); }
 		);
 
-		return pos != std::end(m) ? pos->value() :
+		return pos != std::end(map) ? pos->value() :
 			static_cast<typename map_t::value_type::value_type>(0);
 	}
 }

--- a/substrate/hash
+++ b/substrate/hash
@@ -211,10 +211,10 @@ namespace substrate
 			}
 
 		// Generate CRC for byte 'n'
-		inline constexpr uint32_t calcCrcAtByte(const uint32_t poly, const uint8_t byte) noexcept
-			{ return calcTableC(poly, byte, 8); }
+		inline constexpr uint32_t calcCrcAtByte(const uint32_t poly, const size_t byte) noexcept
+			{ return calcTableC(poly, static_cast<uint32_t>(byte), 8); }
 
-		template<uint8_t N, uint32_t poly, uint32_t... table> struct calcTable
+		template<size_t N, uint32_t poly, uint32_t... table> struct calcTable
 		{
 			constexpr static std::array<const uint32_t, sizeof...(table) + N + 1U> value
 			{

--- a/test/test.cxx
+++ b/test/test.cxx
@@ -6,12 +6,15 @@
 #define CATCH_CONFIG_RUNNER
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/catch_session.hpp>
+#include "substrate/console"
+
+using substrate::console;
 
 #ifdef _WINDOWS
 void invalidHandler(const wchar_t *, const wchar_t *, const wchar_t *, const uint32_t, const uintptr_t) { }
 #endif
 
-int main(int argCount, char **argList)
+int main(int argCount, char **argList) noexcept
 {
 #ifdef _WINDOWS
 	_set_invalid_parameter_handler(invalidHandler);
@@ -19,6 +22,16 @@ int main(int argCount, char **argList)
 	_CrtSetReportMode(_CRT_ERROR, 0);
 #endif
 
-	return Catch::Session().run(argCount, argList);
+	console = {stdout, stderr};
+
+	try
+	{
+		return Catch::Session().run(argCount, argList);
+	}
+	catch (const std::domain_error &error)
+	{
+		console.error("Error running test suite: ", error.what());
+		return 2;
+	}
 }
 /* vim: set ft=cpp ts=4 sw=4 noexpandtab: */


### PR DESCRIPTION
This PR addresses the review items bought up when code reviewing <substrate/command_line> with @freyjadomville. It also addresses several items found when running a Coverity scan such as missed handling of `std::variant::valueless_by_exception() == true`, resulting in possible exception throwing.

Additionally, by request, this addresses some exception mishaps in affinity_t's tests too (again, found by Coverity). As we addressed those, we also cast the net a little broader and went after lints in other parts of the library to help reduce the Coverity footprint and improve the code quality.