### PR TITLE
Feature:command line options autotomatic help generation

### DIFF
--- a/impl/command_line/arguments.cxx
+++ b/impl/command_line/arguments.cxx
@@ -199,14 +199,14 @@ namespace substrate::commandLine
 	static std::optional<optionMatch_t> matchOption(tokeniser_t &lexer, const option_t &option,
 		const std::string_view &argument) noexcept;
 	static std::optional<optionMatch_t> matchOptionSet(tokeniser_t &lexer, const optionSet_t &option,
-		const std::string_view &argument);
-	template<typename set_t> static bool checkMatchValid(const optionsItem_t &option, set_t &optionsVisited);
+		const std::string_view &argument) noexcept;
+	template<typename set_t> static bool checkMatchValid(const optionsItem_t &option, set_t &optionsVisited) noexcept;
 	template<typename set_t> static std::optional<bool> handleResult(arguments_t &arguments, const optionsItem_t &option,
 		set_t &optionsVisited, const std::string_view &argument, const optionMatch_t &match) noexcept;
-	static void handleUnrecognised(tokeniser_t &lexer, const std::string_view &argument);
+	static void handleUnrecognised(tokeniser_t &lexer, const std::string_view &argument) noexcept;
 
 	std::optional<bool> arguments_t::parseArgument(tokeniser_t &lexer, const options_t &options,
-		optionsVisited_t &optionsVisited)
+		optionsVisited_t &optionsVisited) noexcept
 	{
 		// Start by checking we're in a suitable state
 		const auto &token{lexer.token()};
@@ -307,7 +307,7 @@ namespace substrate::commandLine
 	}
 
 	static std::optional<optionMatch_t> matchOptionSet(tokeniser_t &lexer, const optionSet_t &option,
-		const std::string_view &argument)
+		const std::string_view &argument) noexcept
 	{
 		// Check if we're parsing an alternation from a set
 		const auto match{option.matches(argument)};
@@ -326,7 +326,7 @@ namespace substrate::commandLine
 		return choice_t{option.metaName(), argument, std::move(subarguments)};
 	}
 
-	template<typename set_t> static bool checkMatchValid(const optionsItem_t &option, set_t &optionsVisited)
+	template<typename set_t> static bool checkMatchValid(const optionsItem_t &option, set_t &optionsVisited) noexcept
 	{
 		// Look for the option in the set
 		const auto &count{optionsVisited.find(option)};
@@ -364,7 +364,7 @@ namespace substrate::commandLine
 		}, match);
 	}
 
-	static void handleUnrecognised(tokeniser_t &lexer, const std::string_view &argument)
+	static void handleUnrecognised(tokeniser_t &lexer, const std::string_view &argument) noexcept
 	{
 		const auto &token{lexer.next()};
 		// If the argument stands alone, display it and fast exit

--- a/impl/command_line/arguments.cxx
+++ b/impl/command_line/arguments.cxx
@@ -389,6 +389,10 @@ namespace substrate::commandLine
 	// Implementation of the innards of arguments_t as otherwise we get compile errors
 	// NOLINTNEXTLINE(modernize-use-equals-default)
 	arguments_t::arguments_t() noexcept : _arguments{} { }
+	arguments_t::arguments_t(const arguments_t &arguments) noexcept : _arguments{arguments._arguments} { }
+	arguments_t::arguments_t(arguments_t &&arguments) noexcept : _arguments{std::move(arguments._arguments)} { }
+	// NOLINTNEXTLINE(modernize-use-equals-default)
+	arguments_t::~arguments_t() noexcept { }
 	size_t arguments_t::count() const noexcept
 		{ return _arguments.size(); }
 	size_t arguments_t::countMatching(const std::string_view &option) const noexcept
@@ -399,6 +403,18 @@ namespace substrate::commandLine
 		{ return _arguments.end(); }
 	arguments_t::iterator_t arguments_t::find(const std::string_view &option) const noexcept
 		{ return _arguments.find(option); }
+
+	arguments_t &arguments_t::operator =(const arguments_t &arguments) noexcept
+	{
+		_arguments = arguments._arguments;
+		return *this;
+	}
+
+	arguments_t &arguments_t::operator =(arguments_t &&arguments) noexcept
+	{
+		_arguments = std::move(arguments._arguments);
+		return *this;
+	}
 
 	// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 	std::vector<const item_t *> arguments_t::findAll(const std::string_view &option) const noexcept

--- a/impl/command_line/options.cxx
+++ b/impl/command_line/options.cxx
@@ -171,6 +171,18 @@ namespace substrate::commandLine
 		}, _option);
 	}
 
+	[[nodiscard]] size_t option_t::displayLength() const noexcept
+	{
+		return std::visit(match_t
+		{
+			[](const std::string_view &option) { return option.length(); },
+			[](const optionFlagPair_t &option)
+				// Add the lengths of the two flags together, and the extra ", " that is inserted by displayName()
+				{ return option._shortFlag.length() + option._longFlag.length() + 2U; },
+			[](const optionValue_t &option) { return option.metaName().length(); },
+		}, _option);
+	}
+
 	void option_t::displayHelp() const noexcept
 		{ console.writeln('\t', displayName(), ' ', _help); }
 } // namespace substrate::commandLine

--- a/impl/command_line/options.cxx
+++ b/impl/command_line/options.cxx
@@ -201,6 +201,25 @@ namespace substrate::commandLine
 			console.writeln(' ', nullptr);
 		console.writeln(' ', _help);
 	}
+
+	namespace internal
+	{
+		// This calculates how much padding is needed for these options to get a consistent padding
+		[[nodiscard]] size_t optionsHolder_t::displayPadding() const noexcept
+		{
+			return std::accumulate(begin(), end(), size_t{},
+				[](const size_t padding, const optionsItem_t &option) noexcept
+				{
+					return std::max(padding, std::visit(match_t
+						{
+							[](const option_t &value) { return value.displayLength(); },
+							[](const optionSet_t &value) { return value.displayPadding(); },
+						}, option)
+					);
+				}
+			);
+		}
+	} // namespace internal
 } // namespace substrate::commandLine
 
 /* vim: set ft=cpp ts=4 sw=4 noexpandtab: */

--- a/impl/command_line/options.cxx
+++ b/impl/command_line/options.cxx
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 #include <filesystem>
+#include <numeric>
 #include <substrate/command_line/options>
 #include <substrate/console>
 #include <substrate/conversions>
@@ -127,6 +128,15 @@ namespace substrate::commandLine
 				return std::ref(alternation);
 		}
 		return std::nullopt;
+	}
+
+	// This calculates how much padding is needed for these options to get a consistent padding
+	[[nodiscard]] size_t optionSet_t::displayPadding() const noexcept
+	{
+		return std::accumulate(begin(), end(), size_t{},
+			[](const size_t padding, const optionAlternation_t &alternation) noexcept
+				{ return std::max(padding, alternation.displayLength()); }
+		);
 	}
 
 	// Implementation of the innards of optionSet_t as otherwise we get compile errors

--- a/impl/command_line/options.cxx
+++ b/impl/command_line/options.cxx
@@ -237,7 +237,7 @@ namespace substrate::commandLine
 		void optionsHolder_t::displayHelp() const noexcept
 		{
 			// Figure out how much padding is needed to make everything neat
-			const auto padding{displayPadding() + 1U};
+			const auto padding{displayPadding()};
 			std::vector<optionSet_t> optionSets{};
 
 			// Now display the non-alternation options and collect option sets
@@ -250,6 +250,10 @@ namespace substrate::commandLine
 					[&](const optionSet_t &value) { optionSets.push_back(value); },
 				}, option);
 			}
+
+			// Now go through each option alternation set and display those
+			for (const auto &optionSet : optionSets)
+				optionSet.displayHelp(padding);
 		}
 	} // namespace internal
 } // namespace substrate::commandLine

--- a/impl/command_line/options.cxx
+++ b/impl/command_line/options.cxx
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 #include <filesystem>
+#include <locale>
 #include <numeric>
 #include <substrate/command_line/options>
 #include <substrate/console>
@@ -142,8 +143,8 @@ namespace substrate::commandLine
 	void optionSet_t::displayHelp(const size_t padding) const noexcept
 	{
 		console.writeln();
-		// XXX: Need to capitalise the first letter.
-		console.writeln(metaName(), "s:"sv);
+		const auto &metaName{_metaName.substr(1)};
+		console.writeln(std::toupper(_metaName[0], std::locale::classic()), metaName, "s:"sv);
 		for (const auto &alternation : _alternations)
 		{
 			console.writeln('\t', alternation.displayName(), nullptr);

--- a/impl/command_line/options.cxx
+++ b/impl/command_line/options.cxx
@@ -139,6 +139,20 @@ namespace substrate::commandLine
 		);
 	}
 
+	void optionSet_t::displayHelp(const size_t padding) const noexcept
+	{
+		console.writeln();
+		// XXX: Need to capitalise the first letter.
+		console.writeln(metaName(), "s:"sv);
+		for (const auto &alternation : _alternations)
+		{
+			console.writeln('\t', alternation.displayName(), nullptr);
+			for ([[maybe_unused]] const auto _ : substrate::indexSequence_t{alternation.displayLength(), padding})
+				console.writeln(' ', nullptr);
+			console.writeln(' ', alternation.helpText());
+		}
+	}
+
 	// Implementation of the innards of optionSet_t as otherwise we get compile errors
 	const optionAlternation_t *optionSet_t::begin() const noexcept
 		{ return _alternations.begin(); }

--- a/impl/command_line/options.cxx
+++ b/impl/command_line/options.cxx
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: BSD-3-Clause
 #include <filesystem>
 #include <substrate/command_line/options>
-#include <substrate/conversions>
 #include <substrate/console>
+#include <substrate/conversions>
+#include <substrate/index_sequence>
 
 using namespace std::literals::string_literals;
 using namespace std::literals::string_view_literals;
@@ -183,8 +184,13 @@ namespace substrate::commandLine
 		}, _option);
 	}
 
-	void option_t::displayHelp() const noexcept
-		{ console.writeln('\t', displayName(), ' ', _help); }
+	void option_t::displayHelp(const size_t padding) const noexcept
+	{
+		console.writeln('\t', displayName(), nullptr);
+		for ([[maybe_unused]] const auto _ : substrate::indexSequence_t{displayLength(), padding})
+			console.writeln(' ', nullptr);
+		console.writeln(' ', _help);
+	}
 } // namespace substrate::commandLine
 
 /* vim: set ft=cpp ts=4 sw=4 noexpandtab: */

--- a/impl/command_line/options.cxx
+++ b/impl/command_line/options.cxx
@@ -219,6 +219,24 @@ namespace substrate::commandLine
 				}
 			);
 		}
+
+		void optionsHolder_t::displayHelp() const noexcept
+		{
+			// Figure out how much padding is needed to make everything neat
+			const auto padding{displayPadding() + 1U};
+			std::vector<optionSet_t> optionSets{};
+
+			// Now display the non-alternation options and collect option sets
+			console.writeln("Options:"sv);
+			for (const auto &option : *this)
+			{
+				std::visit(match_t
+				{
+					[=](const option_t &value) { value.displayHelp(padding); },
+					[&](const optionSet_t &value) { optionSets.push_back(value); },
+				}, option);
+			}
+		}
 	} // namespace internal
 } // namespace substrate::commandLine
 

--- a/substrate/command_line/arguments
+++ b/substrate/command_line/arguments
@@ -89,10 +89,10 @@ namespace substrate::commandLine
 	};
 
 	[[nodiscard]] SUBSTRATE_API std::optional<arguments_t>
-		parseArguments(size_t argCount, const char *const *argList, const options_t &options);
+		parseArguments(size_t argCount, const char *const *argList, const options_t &options) noexcept;
 
 	[[nodiscard]] inline std::optional<arguments_t>
-		parseArguments(size_t argCount, const char *const *argList, const internal::optionsHolder_t &options)
+		parseArguments(size_t argCount, const char *const *argList, const internal::optionsHolder_t &options) noexcept
 	{
 		const options_t programOptions{options};
 		return parseArguments(argCount, argList, programOptions);

--- a/substrate/command_line/arguments
+++ b/substrate/command_line/arguments
@@ -52,6 +52,11 @@ namespace substrate::commandLine
 
 	public:
 		arguments_t() noexcept;
+		arguments_t(const arguments_t &arguments) noexcept;
+		arguments_t(arguments_t &&arguments) noexcept;
+		~arguments_t() noexcept;
+		arguments_t &operator =(const arguments_t &arguments) noexcept;
+		arguments_t &operator =(arguments_t &&arguments) noexcept;
 
 		[[nodiscard]] bool parseFrom(internal::tokeniser_t &lexer, const options_t &options);
 		[[nodiscard]] bool add(item_t argument) noexcept;

--- a/substrate/command_line/options
+++ b/substrate/command_line/options
@@ -310,6 +310,7 @@ namespace substrate::commandLine
 			constexpr auto end() const noexcept { return optionsIterator_t{storage, length, indexFn}; }
 
 			[[nodiscard]] size_t displayPadding() const noexcept;
+			void displayHelp() const noexcept;
 		};
 	}
 
@@ -333,6 +334,7 @@ namespace substrate::commandLine
 		[[nodiscard]] constexpr auto end() const noexcept { return _options.end(); }
 
 		[[nodiscard]] size_t displayPadding() const noexcept { return _options.displayPadding(); }
+		void displayHelp() const noexcept { _options.displayHelp(); }
 	};
 
 	namespace internal

--- a/substrate/command_line/options
+++ b/substrate/command_line/options
@@ -201,6 +201,8 @@ namespace substrate::commandLine
 		[[nodiscard]] constexpr auto &metaName() const noexcept { return _metaName; }
 		[[nodiscard]] std::optional<std::reference_wrapper<const optionAlternation_t>>
 			matches(const std::string_view &argument) const noexcept;
+		[[nodiscard]] size_t displayPadding() const noexcept;
+
 		[[nodiscard]] const optionAlternation_t *begin() const noexcept;
 		[[nodiscard]] const optionAlternation_t *end() const noexcept;
 

--- a/substrate/command_line/options
+++ b/substrate/command_line/options
@@ -244,6 +244,8 @@ namespace substrate::commandLine
 			constexpr optionsStorage_t &operator =(const optionsStorage_t &) noexcept = default;
 			constexpr optionsItem_t operator [](const size_t index) const { return optionAt<0U>(index, _options); }
 			constexpr auto &options() const noexcept { return _options; }
+
+			void displayHelp() const noexcept;
 		};
 
 		template<typename... options_t> optionsStorage_t(const std::tuple<options_t...> &) ->
@@ -313,6 +315,13 @@ namespace substrate::commandLine
 			[[nodiscard]] size_t displayPadding() const noexcept;
 			void displayHelp() const noexcept;
 		};
+
+		template<typename... options_t>
+			void optionsStorage_t<options_t...>::displayHelp() const noexcept
+		{
+			optionsHolder_t holder{*this};
+			holder.displayHelp();
+		}
 	}
 
 	// The base container for a program's command line options

--- a/substrate/command_line/options
+++ b/substrate/command_line/options
@@ -384,6 +384,10 @@ namespace substrate::commandLine
 
 		[[nodiscard]] bool matches(const std::string_view &argument) const noexcept;
 		[[nodiscard]] constexpr auto &suboptions() const noexcept { return _suboptions; }
+
+		[[nodiscard]] constexpr auto &displayName() const noexcept { return _value; }
+		[[nodiscard]] constexpr auto displayLength() const noexcept { return _value.length(); }
+		[[nodiscard]] constexpr auto &helpText() const noexcept { return _help; }
 	};
 } // namespace substrate::commandLine
 

--- a/substrate/command_line/options
+++ b/substrate/command_line/options
@@ -150,6 +150,7 @@ namespace substrate::commandLine
 
 		[[nodiscard]] std::string_view metaName() const noexcept;
 		[[nodiscard]] std::string displayName() const noexcept;
+		[[nodiscard]] size_t displayLength() const noexcept;
 		[[nodiscard]] constexpr auto &helpText() const noexcept { return _help; }
 
 		[[nodiscard]] constexpr bool operator <(const option_t &other) const noexcept

--- a/substrate/command_line/options
+++ b/substrate/command_line/options
@@ -137,7 +137,6 @@ namespace substrate::commandLine
 
 		[[nodiscard]] bool matches(const std::string_view &argument) const noexcept;
 		[[nodiscard]] std::optional<std::any> parseValue(const std::string_view &value) const noexcept;
-		void displayHelp(size_t padding = 0U) const noexcept;
 
 		[[nodiscard]] constexpr bool takesParameter() const noexcept
 			{ return _flags.includes(optionFlags_t::takesParameter); }
@@ -151,6 +150,7 @@ namespace substrate::commandLine
 		[[nodiscard]] std::string_view metaName() const noexcept;
 		[[nodiscard]] std::string displayName() const noexcept;
 		[[nodiscard]] size_t displayLength() const noexcept;
+		void displayHelp(size_t padding = 0U) const noexcept;
 		[[nodiscard]] constexpr auto &helpText() const noexcept { return _help; }
 
 		[[nodiscard]] constexpr bool operator <(const option_t &other) const noexcept
@@ -202,6 +202,7 @@ namespace substrate::commandLine
 		[[nodiscard]] std::optional<std::reference_wrapper<const optionAlternation_t>>
 			matches(const std::string_view &argument) const noexcept;
 		[[nodiscard]] size_t displayPadding() const noexcept;
+		void displayHelp(size_t padding = 0U) const noexcept;
 
 		[[nodiscard]] const optionAlternation_t *begin() const noexcept;
 		[[nodiscard]] const optionAlternation_t *end() const noexcept;

--- a/substrate/command_line/options
+++ b/substrate/command_line/options
@@ -137,7 +137,7 @@ namespace substrate::commandLine
 
 		[[nodiscard]] bool matches(const std::string_view &argument) const noexcept;
 		[[nodiscard]] std::optional<std::any> parseValue(const std::string_view &value) const noexcept;
-		void displayHelp() const noexcept;
+		void displayHelp(size_t padding = 0U) const noexcept;
 
 		[[nodiscard]] constexpr bool takesParameter() const noexcept
 			{ return _flags.includes(optionFlags_t::takesParameter); }

--- a/substrate/command_line/options
+++ b/substrate/command_line/options
@@ -308,6 +308,8 @@ namespace substrate::commandLine
 			constexpr auto empty() const noexcept { return storage == nullptr; }
 			constexpr auto begin() const noexcept { return optionsIterator_t{storage, 0U, indexFn}; }
 			constexpr auto end() const noexcept { return optionsIterator_t{storage, length, indexFn}; }
+
+			[[nodiscard]] size_t displayPadding() const noexcept;
 		};
 	}
 
@@ -329,6 +331,8 @@ namespace substrate::commandLine
 		[[nodiscard]] constexpr auto empty() const noexcept { return _options.empty(); }
 		[[nodiscard]] constexpr auto begin() const noexcept { return _options.begin(); }
 		[[nodiscard]] constexpr auto end() const noexcept { return _options.end(); }
+
+		[[nodiscard]] size_t displayPadding() const noexcept { return _options.displayPadding(); }
 	};
 
 	namespace internal


### PR DESCRIPTION
In this PR we extend the substrate/command_line/options subsystem to allow the help strings contained within to then be used to generate automatic help listings for programs.