### PR TITLE
fd: Use non-deprecated close and dup in Windows

### DIFF
--- a/substrate/fd
+++ b/substrate/fd
@@ -60,7 +60,7 @@ namespace substrate
 		~fd_t() noexcept
 		{
 			if (fd != -1)
-				close(fd);
+				internal::fdclose(fd);
 		}
 
 		fd_t &operator =(fd_t &&desc) noexcept
@@ -100,7 +100,7 @@ namespace substrate
 			{ return internal::fdwrite(fd, bufferPtr, bufferLen); }
 		SUBSTRATE_NO_DISCARD(off_t tell() const noexcept final) { return internal::fdtell(fd); }
 
-		SUBSTRATE_NO_DISCARD(fd_t dup() const noexcept) { return ::dup(fd); }
+		SUBSTRATE_NO_DISCARD(fd_t dup() const noexcept) { return internal::fddup(fd); }
 
 		SUBSTRATE_NO_DISCARD(internal::stat_t stat() const noexcept)
 		{

--- a/substrate/internal/fd_compat
+++ b/substrate/internal/fd_compat
@@ -53,6 +53,11 @@ namespace substrate
 			{ return lseek(fd, 0, SEEK_CUR); }
 		inline int32_t fdtruncate(const int32_t fd, const off_t size) noexcept
 			{ return ftruncate(fd, size); }
+
+		inline int32_t fdclose(const int32_t fd) noexcept
+			{ return close(fd); }
+		inline int32_t fddup(const int32_t fd) noexcept
+			{ return dup(fd); }
 #else
 		inline int32_t fdopen(const char *const fileName, const int flags, const mode_t mode) noexcept
 		{
@@ -79,6 +84,11 @@ namespace substrate
 			{ return _telli64(fd); }
 		inline int32_t fdtruncate(const int32_t fd, const off_t size) noexcept
 			{ return _chsize_s(fd, size); }
+
+		inline int32_t fdclose(const int32_t fd) noexcept
+			{ return _close(fd); }
+		inline int32_t fddup(const int32_t fd) noexcept
+			{ return _dup(fd); }
 #endif
 	} // namespace substrate::internal
 } // namespace substrate


### PR DESCRIPTION
This avoids warning C4996 in MSVC.