### PR TITLE
iterator: Remove ineffective const in base() return type

### DIFF
--- a/substrate/iterator
+++ b/substrate/iterator
@@ -78,7 +78,7 @@ namespace substrate
 			return *this;
 		}
 
-		const iterator_t base() const noexcept { return current; }
+		iterator_t base() const noexcept { return current; }
 	};
 
 	template<typename iteratorL_t, typename iteratorR_t, typename container_t> inline bool operator ==(


### PR DESCRIPTION
Hey @dragonmux,

This fixes a lint in clang-tidy:

> Return type 'const iterator_t' is 'const'-qualified at the top level, which may reduce code readability without improving const correctness (fix available) clang-tidy([readability-const-return-type](https://clang.llvm.org/extra/clang-tidy/checks/readability/const-return-type.html))

It's also picked up by MSVC if warning C5266 is enabled.

