### PR TITLE
Fix: missing constructors and operators in substrate/console

### DIFF
--- a/substrate/console
+++ b/substrate/console
@@ -225,6 +225,11 @@ namespace substrate
 
 	public:
 		constexpr asInt_t(const int_t value) noexcept : value_{value} { }
+		constexpr asInt_t(const asInt_t &) noexcept = default;
+		constexpr asInt_t(asInt_t &&) noexcept = default;
+		~asInt_t() noexcept = default;
+		asInt_t &operator =(const asInt_t &) noexcept = default;
+		asInt_t &operator =(asInt_t &&) noexcept = default;
 		void operator()(const consoleStream_t &stream) const noexcept final
 			{ printTo<int_t>(stream); }
 	};

--- a/substrate/console
+++ b/substrate/console
@@ -262,8 +262,13 @@ namespace substrate
 			constexpr asHex_t(const T value) noexcept : maxDigits{sizeof(T) * 2},
 			msbShift{uint8_t(4U * (maxDigits - 1U))}, _value(value) { }
 
-		SUBSTRATE_NOINLINE
-		void operator ()(const consoleStream_t &stream) const noexcept final
+		constexpr asHex_t(const asHex_t &) noexcept = default;
+		constexpr asHex_t(asHex_t &&) noexcept = default;
+		~asHex_t() noexcept = default;
+		asHex_t &operator =(const asHex_t &) noexcept = default;
+		asHex_t &operator =(asHex_t &&) noexcept = default;
+
+		SUBSTRATE_NOINLINE void operator ()(const consoleStream_t &stream) const noexcept final
 		{
 			uintmax_t value{_value};
 			// If we've been asked to pad by more than the maximum possible length of the number

--- a/substrate/console
+++ b/substrate/console
@@ -56,8 +56,8 @@ namespace substrate
 	public:
 		constexpr consoleStream_t() noexcept = default;
 		consoleStream_t(const int32_t desc) noexcept : fd{desc} { checkTTY(); }
-		constexpr bool valid() const noexcept { return fd != -1; }
-		constexpr bool isTTY() const noexcept { return _tty; }
+		SUBSTRATE_NO_DISCARD(constexpr bool valid() const noexcept) { return fd != -1; }
+		SUBSTRATE_NO_DISCARD(constexpr bool isTTY() const noexcept) { return _tty; }
 #if defined(_WIN32)
 		void *handle() const noexcept { return reinterpret_cast<void *>(_get_osfhandle(fd)); }
 #endif
@@ -299,7 +299,7 @@ namespace substrate
 					stream.write(char(digit + 7));
 				else
 					stream.write(digit);
-				value <<= 4;
+				value <<= 4U;
 			}
 		}
 	};

--- a/substrate/console
+++ b/substrate/console
@@ -34,14 +34,15 @@ namespace substrate
 
 	struct SUBSTRATE_CLS_API printable_t
 	{
-		printable_t() = default;
+		constexpr printable_t() = default;
 		virtual void operator()(const consoleStream_t &) const noexcept = 0;
 		virtual ~printable_t() noexcept = default;
 
-		printable_t(const printable_t &) = delete;
-		printable_t(printable_t &&) = delete;
-		printable_t &operator =(const printable_t &) = delete;
-		printable_t &operator =(printable_t &&) = delete;
+	protected:
+		constexpr printable_t(const printable_t &) = default;
+		constexpr printable_t(printable_t &&) = default;
+		printable_t &operator =(const printable_t &) = default;
+		printable_t &operator =(printable_t &&) = default;
 	};
 
 	struct SUBSTRATE_CLS_API consoleStream_t final
@@ -227,7 +228,7 @@ namespace substrate
 		constexpr asInt_t(const int_t value) noexcept : value_{value} { }
 		constexpr asInt_t(const asInt_t &) noexcept = default;
 		constexpr asInt_t(asInt_t &&) noexcept = default;
-		~asInt_t() noexcept = default;
+		~asInt_t() noexcept final = default;
 		asInt_t &operator =(const asInt_t &) noexcept = default;
 		asInt_t &operator =(asInt_t &&) noexcept = default;
 		void operator()(const consoleStream_t &stream) const noexcept final
@@ -264,7 +265,7 @@ namespace substrate
 
 		constexpr asHex_t(const asHex_t &) noexcept = default;
 		constexpr asHex_t(asHex_t &&) noexcept = default;
-		~asHex_t() noexcept = default;
+		~asHex_t() noexcept final = default;
 		asHex_t &operator =(const asHex_t &) noexcept = default;
 		asHex_t &operator =(asHex_t &&) noexcept = default;
 
@@ -342,7 +343,7 @@ namespace substrate
 		constexpr asTime_t(const uint64_t _value) noexcept : value{_value} { }
 		constexpr asTime_t(const asTime_t &) noexcept = default;
 		constexpr asTime_t(asTime_t &&) noexcept = default;
-		~asTime_t() noexcept = default;
+		~asTime_t() noexcept final = default;
 		asTime_t &operator =(const asTime_t &) noexcept = default;
 		asTime_t &operator =(asTime_t &&) noexcept = default;
 

--- a/substrate/console
+++ b/substrate/console
@@ -330,6 +330,11 @@ namespace substrate
 
 	public:
 		constexpr asTime_t(const uint64_t _value) noexcept : value{_value} { }
+		constexpr asTime_t(const asTime_t &) noexcept = default;
+		constexpr asTime_t(asTime_t &&) noexcept = default;
+		~asTime_t() noexcept = default;
+		asTime_t &operator =(const asTime_t &) noexcept = default;
+		asTime_t &operator =(asTime_t &&) noexcept = default;
 
 		void operator ()(const consoleStream_t &stream) const noexcept final
 		{


### PR DESCRIPTION
In this PR we aim to fix how `printable_t` is defined and how the `asN_t` types failed to properly define constructors, destructors and assignment operators, thus failing the Rule of 5 requirements on them.

The goal here is to address several MSVC warnings and clang-tidy lints which indicate broken code, with the intent of getting the [blackmagic-debug/bmpflash](https://github.com/blackmagic-debug/bmpflash) build closer to warning-free ahead of cutting releases of this library and that program.