### PR TITLE
Fix: std::filesystem include issues

### DIFF
--- a/impl/meson.build
+++ b/impl/meson.build
@@ -5,6 +5,7 @@ libSubstrateSrcs = [
 ]
 
 deps = []
+libSubstrateArgs = []
 
 if target_machine.system() == 'windows'
 	deps += cxx.find_library('ws2_32', required: true)
@@ -81,6 +82,10 @@ if cxxVersion.version_compare('>=201703')
 		dependencies: libstdcppFS,
 	)
 
+	if stdFilesystemPath
+		libSubstrateArgs += ['-DHAVE_FILESYSTEM_PATH']
+	endif
+
 	initializerListTest = '''
 		#include <array>
 		#include <cstdint>
@@ -143,8 +148,6 @@ library_type = get_option('default_library')
 if library_type == 'both' and isWindows
   error('On Windows default_library must be "shared" or "static" but not "both"')
 endif
-
-libSubstrateArgs = []
 
 if library_type == 'static' and isWindows
 	libSubstrateArgs = ['-DSUBSTRATE_BUILD_STATIC']

--- a/substrate/internal/defs
+++ b/substrate/internal/defs
@@ -62,7 +62,7 @@
 #elif defined(_WIN32)
 #	define SUBSTRATE_NOINLINE __declspec(noinline)
 #else
-#	define SUBSTRATE_NOINLINE 
+#	define SUBSTRATE_NOINLINE
 #endif
 
 #ifdef _MSC_VER
@@ -118,7 +118,8 @@
 #	define SUBSTRATE_DEDUCTION_GUIDE(...)
 #endif
 
-#if __cplusplus >= 201703L && defined(__cpp_lib_filesystem) && __cpp_lib_filesystem >= 201703L
+#if __cplusplus >= 201703L && (defined(HAS_FILESYSTEM_PATH) || \
+	(defined(__cpp_lib_filesystem) && __cpp_lib_filesystem >= 201703L))
 #	if !defined(__APPLE__)
 #		define SUBSTRATE_ALLOW_STD_FILESYSTEM_PATH 1
 #	else

--- a/substrate/internal/defs
+++ b/substrate/internal/defs
@@ -2,6 +2,15 @@
 #ifndef SUBSTRATE_INTERNAL_DEFS
 #define SUBSTRATE_INTERNAL_DEFS
 
+#if !defined(__has_include)
+// NOLINTNEXTLINE(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp)
+#define __has_include(x) 0
+#endif
+
+#if __has_include(<version>)
+#include <version>
+#endif
+
 #if defined(_MSC_VER) || defined(__MINGW64__) || defined(__MINGW32__)
 #	if !defined(_WIN32)
 #		define _WIN32 1
@@ -9,6 +18,7 @@
 #endif
 
 #if !defined(__has_cpp_attribute)
+// NOLINTNEXTLINE(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp)
 #	define __has_cpp_attribute(x) 0
 #endif
 


### PR DESCRIPTION
As part of getting CI for bmpflash up and working, we encountered a series of issues surrounding <filesystem> and getting the checks for it being enabled right. This PR seeks to improve this situation by, among other things, including the <version> header to ensure the proper feature macros are available in <substrate/include/defs> and improve the logic for defining the guard macro.

The result should be a much more robust path to getting `SUBSTRATE_ALLOW_STD_FILESYSTEM_PATH` defined in appropriate circumstances.