### PR TITLE
Feature: command line parser enabled var

### DIFF
--- a/impl/command_line/meson.build
+++ b/impl/command_line/meson.build
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: BSD-3-Clause
-libSubstrateSrcs += files(
+libSubstrateCommandLineSrcs = files(
 	'tokeniser.cxx', 'arguments.cxx', 'options.cxx'
 )

--- a/impl/meson.build
+++ b/impl/meson.build
@@ -3,9 +3,12 @@ libSubstrateSrcs = [
 	'socket.cxx', 'console.cxx', 'affinity.cxx', 'thread.cxx',
 	'utility.cxx', 'hash.cxx',
 ]
+subdir('command_line')
 
 deps = []
 libSubstrateArgs = []
+# Clone the sources list for the native build if it's required.
+libSubstrateNativeSrcs = [] + libSubstrateSrcs
 
 if target_machine.system() == 'windows'
 	deps += cxx.find_library('ws2_32', required: true)
@@ -128,8 +131,7 @@ if cxxVersion.version_compare('>=201703')
 	substrateCommandLineEnabled = friendTypenameTemplate and stdVariantGCC and stdFilesystemPath and initializerList
 	if substrateCommandLineEnabled
 		deps += [libstdcppFS]
-
-		subdir('command_line')
+		libSubstrateSrcs += libSubstrateCommandLineSrcs
 	endif
 else
 	substrateCommandLineEnabled = false
@@ -208,6 +210,17 @@ endif
 if meson.is_cross_build()
 	hostCXX = meson.get_compiler('cpp', native: true)
 
+	depsNative = []
+
+	if build_machine.system() == 'windows'
+		depsNative += hostCXX.find_library('ws2_32', required: true)
+		depsNative += hostCXX.find_library('dbghelp', required: true)
+	else
+		libSubstrateNativeSrcs += 'pty.cxx'
+	endif
+
+	depsNative += dependency('threads', native: true)
+
 	if hostCXX.get_define('__cplusplus').substring(0, -1).version_compare('>=201703')
 		# Re-check if we should or can enable the command line handling stuff by checking
 		# everything again against the host compiler
@@ -237,9 +250,8 @@ if meson.is_cross_build()
 
 		substrateNativeCommandLineEnabled = friendTypenameTemplate and stdVariantGCC and stdFilesystemPath and initializerList
 		if substrateNativeCommandLineEnabled
-			deps += [libstdcppFS]
-
-			subdir('command_line')
+			depsNative += [libstdcppFS]
+			libSubstrateNativeSrcs += libSubstrateCommandLineSrcs
 		endif
 	else
 		substrateNativeCommandLineEnabled = false
@@ -247,11 +259,11 @@ if meson.is_cross_build()
 
 	libSubstrateNative = library(
 		'substrateNative',
-		libSubstrateSrcs,
+		libSubstrateNativeSrcs,
 		c_args: ['-DSUBSTRATE_BUILD_INTERNAL'] + libSubstrateArgs,
 		cpp_args: ['-DSUBSTRATE_BUILD_INTERNAL'] + libSubstrateArgs,
 		include_directories: include_directories('..'),
-		dependencies: deps,
+		dependencies: depsNative,
 		gnu_symbol_visibility: 'inlineshidden',
 		implicit_include_directories: false,
 		pic: true,

--- a/impl/meson.build
+++ b/impl/meson.build
@@ -125,11 +125,14 @@ if cxxVersion.version_compare('>=201703')
 		name: 'accepts nullptr as part of CTAD with pointer type values (GCC #85977)'
 	)
 
-	if friendTypenameTemplate and stdVariantGCC and stdFilesystemPath and initializerList
+	substrateCommandLineEnabled = friendTypenameTemplate and stdVariantGCC and stdFilesystemPath and initializerList
+	if substrateCommandLineEnabled
 		deps += [libstdcppFS]
 
 		subdir('command_line')
 	endif
+else
+	substrateCommandLineEnabled = false
 endif
 
 # This is by far not a complete set of conditions, however..
@@ -232,11 +235,14 @@ if meson.is_cross_build()
 			name: 'accepts nullptr as part of CTAD with pointer type values (GCC #85977)'
 		)
 
-		if friendTypenameTemplate and stdVariantGCC and stdFilesystemPath and initializerList
+		substrateNativeCommandLineEnabled = friendTypenameTemplate and stdVariantGCC and stdFilesystemPath and initializerList
+		if substrateNativeCommandLineEnabled
 			deps += [libstdcppFS]
 
 			subdir('command_line')
 		endif
+	else
+		substrateNativeCommandLineEnabled = false
 	endif
 
 	libSubstrateNative = library(

--- a/impl/meson.build
+++ b/impl/meson.build
@@ -208,42 +208,42 @@ endif
 
 # In a cross-build scenario, always build a version of the library for the host too.
 if meson.is_cross_build()
-	hostCXX = meson.get_compiler('cpp', native: true)
+	buildCXX = meson.get_compiler('cpp', native: true)
 
 	depsNative = []
 
 	if build_machine.system() == 'windows'
-		depsNative += hostCXX.find_library('ws2_32', required: true)
-		depsNative += hostCXX.find_library('dbghelp', required: true)
+		depsNative += buildCXX.find_library('ws2_32', required: true)
+		depsNative += buildCXX.find_library('dbghelp', required: true)
 	else
 		libSubstrateNativeSrcs += 'pty.cxx'
 	endif
 
 	depsNative += dependency('threads', native: true)
 
-	if hostCXX.get_define('__cplusplus').substring(0, -1).version_compare('>=201703')
+	if buildCXX.get_define('__cplusplus').substring(0, -1).version_compare('>=201703')
 		# Re-check if we should or can enable the command line handling stuff by checking
 		# everything again against the host compiler
-		friendTypenameTemplate = hostCXX.compiles(
+		friendTypenameTemplate = buildCXX.compiles(
 			friendTypenameTest,
 			name: 'accepts friend declarations for auto functions (LLVM #31852, #33222)'
 		)
 
-		stdVariantGCC = hostCXX.compiles(
+		stdVariantGCC = buildCXX.compiles(
 			stdVariantGCCTest,
 			name: 'has a working std::variant implementation (GCC #80165)'
 		)
 
 		# GCC < 9.1 splits the filesystem module into a separate library
-		libstdcppFS = hostCXX.find_library('stdc++fs', required: false)
+		libstdcppFS = buildCXX.find_library('stdc++fs', required: false)
 
-		stdFilesystemPath = hostCXX.links(
+		stdFilesystemPath = buildCXX.links(
 			stdFilesystemPathTest,
 			name: 'has a working std::filesystem::path implementation (GCC >= 8 in macOS pre 10.15)',
 			dependencies: libstdcppFS,
 		)
 
-		initializerList = hostCXX.compiles(
+		initializerList = buildCXX.compiles(
 			initializerListTest,
 			name: 'accepts nullptr as part of CTAD with pointer type values (GCC #85977)'
 		)

--- a/meson.build
+++ b/meson.build
@@ -145,6 +145,9 @@ if not meson.is_subproject() and get_option('build_library')
 		libraries: [libSubstrate, deps],
 		version: meson.project_version(),
 		extra_cflags: libSubstrateArgs,
+		variables: [
+			'command_line_enabled=@0@'.format(substrateCommandLineEnabled),
+		],
 		description: 'A collection of headers containing useful tools and gadgets for building C++ programs'
 	)
 endif

--- a/meson.build
+++ b/meson.build
@@ -155,6 +155,7 @@ variablesCompileArgs = [
 
 variables = {
 	'compile_args': ' '.join(variablesCompileArgs),
+	'command_line_enabled': substrateCommandLineEnabled.to_string(),
 }
 
 nativeDeps = deps
@@ -193,7 +194,8 @@ if meson.is_cross_build()
 		link_with: libSubstrateNative,
 		variables: {
 			'compile_args': substrateNativeArgs,
-			'link_args': libSubstrateNative.full_path()
+			'link_args': libSubstrateNative.full_path(),
+			'command_line_enabled': substrateNativeCommandLineEnabled.to_string(),
 		},
 		version: meson.project_version()
 	)

--- a/meson.build
+++ b/meson.build
@@ -188,7 +188,7 @@ endif
 if meson.is_cross_build()
 	substrateNativeArgs = ' '.join(['-I@0@'.format(meson.current_source_dir())] + libSubstrateArgs)
 	substrateNative_dep = declare_dependency(
-		dependencies: deps,
+		dependencies: depsNative,
 		include_directories: include_directories('.'),
 		compile_args: substrateNativeArgs,
 		link_with: libSubstrateNative,


### PR DESCRIPTION
This PR adds a variable to the build system to denote when the command line parser has been enabled. This is to allow dependent builds to detect this condition and depend on the command line parser.

Additionally, this PR sorts a long-standing issue with the host vs target (native, non-native) builds where state from one would leak into the other in potentially bad ways and cause a malodorous mess if cross-compiling to Windows from Linux (for example).