### PR TITLE
Feature: Improved Windows console text handling

### DIFF
--- a/impl/console.cxx
+++ b/impl/console.cxx
@@ -72,6 +72,7 @@ namespace substrate
 			const auto consoleMode{_setmode(fd, _O_U8TEXT)};
 			const auto stringLen{static_cast<size_t>(MultiByteToWideChar(CP_UTF8, MB_PRECOMPOSED | MB_USEGLYPHCHARS,
 				value, int(valueLen), nullptr, 0))};
+			// NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
 			auto string{make_unique_nothrow<wchar_t []>(stringLen)};
 			if (!string)
 				return;

--- a/impl/console.cxx
+++ b/impl/console.cxx
@@ -21,6 +21,7 @@ using charTraits = std::char_traits<char>;
 #ifdef _WIN32
 using wcharTraits = std::char_traits<wchar_t>;
 #endif
+using char16Traits = std::char_traits<char16_t>;
 
 static const std::string errorPrefix{"[ERR]"_s};
 static const std::string warningPrefix{"[WRN]"_s};
@@ -107,6 +108,28 @@ namespace substrate
 			write(nullString);
 	}
 #endif
+
+	void consoleStream_t::write(const char16_t *const value) const noexcept
+		{ write(value, value ? char16Traits::length(value) : 0U); }
+
+	void consoleStream_t::write(const char16_t *const value, const size_t valueLen) const noexcept
+	{
+		if (value)
+		{
+			// If there's nothing to convert (0-length string), fast-exit doing nothing.
+			if (!valueLen)
+				return;
+#ifdef _WIN32
+			const auto consoleMode{_setmode(fd, _O_U16TEXT)};
+			write(static_cast<const void *>(value), sizeof(char16_t) * valueLen);
+			_setmode(fd, consoleMode);
+#else
+			//
+#endif
+		}
+		else
+			write(nullString);
+	}
 
 	void consoleStream_t::write(const bool value) const noexcept
 		{ write(value ? trueString : falseString); }

--- a/impl/console.cxx
+++ b/impl/console.cxx
@@ -42,6 +42,7 @@ static const std::string falseString{"false"_s};
 
 namespace substrate
 {
+	// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 	console_t console;
 
 	void consoleStream_t::checkTTY() noexcept { _tty = isatty(fd); }

--- a/impl/console.cxx
+++ b/impl/console.cxx
@@ -1,9 +1,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 #include <cerrno>
-#if defined(_MSC_VER) && !defined(_WINDOWS)
-#	define _WINDOWS 1
-#endif
-#ifndef _WINDOWS
+#ifndef _WIN32
 #	include <unistd.h>
 #else
 #	ifndef NOMINMAX
@@ -27,7 +24,7 @@ static const std::string warningPrefix{"[WRN]"_s};
 static const std::string infoPrefix{"[INF]"_s};
 static const std::string debugPrefix{"[DBG]"_s};
 
-#ifndef _WINDOWS
+#ifndef _WIN32
 static const std::string colourRed{"\033[1;31m"_s};
 static const std::string colourYellow{"\033[1;33m"_s};
 static const std::string colourCyan{"\033[36m"_s};
@@ -48,7 +45,7 @@ namespace substrate
 	void consoleStream_t::write(const void *const buffer, const size_t bufferLen) const noexcept
 	{
 		// We don't actually care if this succeeds. We just try if at all possible.
-#ifndef _WINDOWS
+#ifndef _WIN32
 		SUBSTRATE_NOWARN_UNUSED(const auto result) = ::write(fd, buffer, bufferLen);
 #else
 		SUBSTRATE_NOWARN_UNUSED(const auto result) = ::write(fd, buffer, uint32_t(bufferLen));
@@ -65,7 +62,7 @@ namespace substrate
 	{
 		if (value)
 		{
-#ifdef _WINDOWS
+#ifdef _WIN32
 			// If there's nothing to convert (0-length string), fast-exit doing nothing.
 			if (!valueLen)
 				return;
@@ -94,7 +91,7 @@ namespace substrate
 		outputStream{fileno(outStream)}, errorStream{fileno(errStream)},
 		valid_{outputStream.valid() && errorStream.valid()} { }
 
-#ifndef _WINDOWS
+#ifndef _WIN32
 	inline void red(const consoleStream_t &stream) noexcept
 		{ stream.write(colourRed); }
 	inline void yellow(const consoleStream_t &stream) noexcept

--- a/impl/console.cxx
+++ b/impl/console.cxx
@@ -18,6 +18,9 @@
 
 using substrate::operator ""_s;
 using charTraits = std::char_traits<char>;
+#ifdef _WIN32
+using wcharTraits = std::char_traits<wchar_t>;
+#endif
 
 static const std::string errorPrefix{"[ERR]"_s};
 static const std::string warningPrefix{"[WRN]"_s};
@@ -83,6 +86,26 @@ namespace substrate
 		else
 			write(nullString);
 	}
+
+#ifdef _WIN32
+	void consoleStream_t::write(const wchar_t *const value) const noexcept
+		{ write(value, value ? wcharTraits::length(value) : 0U); }
+
+	void consoleStream_t::write(const wchar_t *const value, const size_t valueLen) const noexcept
+	{
+		if (value)
+		{
+			// If there's nothing to convert (0-length string), fast-exit doing nothing.
+			if (!valueLen)
+				return;
+			const auto consoleMode{_setmode(fd, _O_WTEXT)};
+			write(static_cast<const void *>(value), sizeof(wchar_t) * valueLen);
+			_setmode(fd, consoleMode);
+		}
+		else
+			write(nullString);
+	}
+#endif
 
 	void consoleStream_t::write(const bool value) const noexcept
 		{ write(value ? trueString : falseString); }

--- a/impl/meson.build
+++ b/impl/meson.build
@@ -19,62 +19,98 @@ endif
 
 deps += dependency('threads')
 
-if cxxVersion.version_compare('>=201703')
-	friendTypenameTest = '''
+friendTypenameTest = '''
+	template <typename U>
+	auto foo(U u)
+	{
+		u.v;
+	}
+
+	template <typename T>
+	class X
+	{
+		T v;
+
+	public:
 		template <typename U>
-		auto foo(U u)
-		{
-			u.v;
-		}
+		friend auto foo(U);
+	};
 
-		template <typename T>
-		class X
-		{
-			T v;
+	int main()
+	{
+		::foo(X<int>{});
+	}
+'''
 
-		public:
-			template <typename U>
-			friend auto foo(U);
-		};
+stdVariantGCCTest = '''
+	#include <tuple>
+	#include <variant>
+	int main() {
+		using variant_t = std::variant<short, int, long>;
+		constexpr auto variant_v = variant_t{std::in_place_index_t<0>{}, short{}};
+		constexpr auto tuple = std::make_tuple(variant_v);
+		constexpr std::tuple tuple_v{variant_v};
+	}
+'''
 
-		int main()
-		{
-			::foo(X<int>{});
-		}
-	'''
+stdFilesystemPathTest = '''
+	#include <filesystem>
+	#include <iostream>
+
+	using namespace std::literals::string_view_literals;
+
+	int main() {
+		std::filesystem::path p{"/bin/bash"sv};
+		std::cout << p << std::endl;
+		return 0;
+	}
+'''
+
+initializerListTest = '''
+	#include <array>
+	#include <cstdint>
+
+	using size_t = std::size_t;
+
+	namespace internal
+	{
+	template<std::size_t... seq> using indexSequence_t = std::index_sequence<seq...>;
+	template<std::size_t N> using makeIndexSequence = std::make_index_sequence<N>;
+
+	template<typename T, size_t N, size_t... index> constexpr std::array<T, N>
+		makeArray(T (&&elems)[N], indexSequence_t<index...>)
+	{
+		return {{elems[index]...}};
+	}
+	} // namespace internal
+
+	template<typename T, size_t N> constexpr std::array<T, N>
+		make_array(T (&&elems)[N]) // NOLINT(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
+	{
+		return internal::makeArray(std::move(elems), internal::makeIndexSequence<N>{});
+	}
+
+	int main()
+	{
+		auto test = make_array<const char *>({
+			"program",
+			"choiceC",
+			nullptr,
+		});
+	}
+'''
+
+if cxxVersion.version_compare('>=201703')
 	friendTypenameTemplate = cxx.compiles(
 		friendTypenameTest,
 		name: 'accepts friend declarations for auto functions (LLVM #31852, #33222)'
 	)
 
-	stdVariantGCCTest = '''
-		#include <tuple>
-		#include <variant>
-		int main() {
-			using variant_t = std::variant<short, int, long>;
-			constexpr auto variant_v = variant_t{std::in_place_index_t<0>{}, short{}};
-			constexpr auto tuple = std::make_tuple(variant_v);
-			constexpr std::tuple tuple_v{variant_v};
-		}
-	'''
 
 	stdVariantGCC = cxx.compiles(
 		stdVariantGCCTest,
 		name: 'has a working std::variant implementation (GCC #80165)'
 	)
-
-	stdFilesystemPathTest = '''
-		#include <filesystem>
-		#include <iostream>
-
-		using namespace std::literals::string_view_literals;
-
-		int main() {
-			std::filesystem::path p{"/bin/bash"sv};
-			std::cout << p << std::endl;
-			return 0;
-		}
-	'''
 
 	# GCC < 9.1 splits the filesystem module into a separate library
 	libstdcppFS = cxx.find_library('stdc++fs', required: false)
@@ -88,40 +124,6 @@ if cxxVersion.version_compare('>=201703')
 	if stdFilesystemPath
 		libSubstrateArgs += ['-DHAVE_FILESYSTEM_PATH']
 	endif
-
-	initializerListTest = '''
-		#include <array>
-		#include <cstdint>
-
-		using size_t = std::size_t;
-
-		namespace internal
-		{
-		template<std::size_t... seq> using indexSequence_t = std::index_sequence<seq...>;
-		template<std::size_t N> using makeIndexSequence = std::make_index_sequence<N>;
-
-		template<typename T, size_t N, size_t... index> constexpr std::array<T, N>
-			makeArray(T (&&elems)[N], indexSequence_t<index...>)
-		{
-			return {{elems[index]...}};
-		}
-		} // namespace internal
-
-		template<typename T, size_t N> constexpr std::array<T, N>
-			make_array(T (&&elems)[N]) // NOLINT(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
-		{
-			return internal::makeArray(std::move(elems), internal::makeIndexSequence<N>{});
-		}
-
-		int main()
-		{
-			auto test = make_array<const char *>({
-				"program",
-				"choiceC",
-				nullptr,
-			});
-		}
-	'''
 
 	initializerList = cxx.compiles(
 		initializerListTest,

--- a/impl/meson.build
+++ b/impl/meson.build
@@ -269,7 +269,7 @@ if meson.is_cross_build()
 		gnu_symbol_visibility: 'inlineshidden',
 		implicit_include_directories: false,
 		pic: true,
-		install: (not meson.is_subproject()),
+		install: false,
 		native: true,
 	)
 endif

--- a/impl/socket.cxx
+++ b/impl/socket.cxx
@@ -22,7 +22,7 @@
 using substrate::INVALID_SOCKET;
 inline int closesocket(const int s) { return close(s); }
 #else
-#	include <Winsock2.h>
+#	include <winsock2.h>
 #endif
 
 using namespace substrate;

--- a/meson.build
+++ b/meson.build
@@ -55,7 +55,7 @@ extended_warnings = [
 	'-Wpacked',
 #	'-Wpadded',
 	'-Wredundant-decls',
-	'-Winline',
+#	'-Winline',
 	'-Wvla',
 	'-Wstack-protector',
 	'-Wunsuffixed-float-constant',

--- a/substrate/console
+++ b/substrate/console
@@ -60,7 +60,8 @@ namespace substrate
 		SUBSTRATE_NO_DISCARD(constexpr bool valid() const noexcept) { return fd != -1; }
 		SUBSTRATE_NO_DISCARD(constexpr bool isTTY() const noexcept) { return _tty; }
 #if defined(_WIN32)
-		void *handle() const noexcept { return reinterpret_cast<void *>(_get_osfhandle(fd)); }
+		SUBSTRATE_NO_DISCARD(void *handle() const noexcept)
+			{ return reinterpret_cast<void *>(_get_osfhandle(fd)); }
 #endif
 
 		void write(const void *buffer, size_t bufferLen) const noexcept;

--- a/substrate/console
+++ b/substrate/console
@@ -71,6 +71,8 @@ namespace substrate
 		void write(const wchar_t *value) const noexcept;
 		void write(const wchar_t *value, size_t valueLen) const noexcept;
 #endif
+		void write(const char16_t *value) const noexcept;
+		void write(const char16_t *value, size_t valueLen) const noexcept;
 		void write(const char value) const noexcept { write(&value, 1U); }
 		template<typename T> enable_if_t<!std::is_array<T>::value>
 			write(const std::unique_ptr<T> &value) const noexcept
@@ -84,6 +86,8 @@ namespace substrate
 		void write(const std::wstring &value) const noexcept
 			{ write(value.data(), value.length()); }
 #endif
+		void write(const std::u16string &value) const noexcept
+			{ write(value.data(), value.length()); }
 #if __cplusplus >= 201703L
 		void write(const std::string_view &value) const noexcept
 			{ write(value.data(), value.length()); }

--- a/substrate/console
+++ b/substrate/console
@@ -65,7 +65,8 @@ namespace substrate
 
 		void write(const void *buffer, size_t bufferLen) const noexcept;
 		void write(const char *value) const noexcept;
-		void write(const char value) const noexcept { write(&value, 1); }
+		void write(const char *value, size_t valueLen) const noexcept;
+		void write(const char value) const noexcept { write(&value, 1U); }
 		template<typename T> enable_if_t<!std::is_array<T>::value>
 			write(const std::unique_ptr<T> &value) const noexcept
 			{ value ? write(*value) : write("(null)"_s); }

--- a/substrate/console
+++ b/substrate/console
@@ -53,13 +53,16 @@ namespace substrate
 		bool _tty{false};
 
 		void checkTTY() noexcept;
+#ifndef _WIN32
+		void convertingWrite(const char16_t *string, const size_t stringLen) const noexcept;
+#endif
 
 	public:
 		constexpr consoleStream_t() noexcept = default;
 		consoleStream_t(const int32_t desc) noexcept : fd{desc} { checkTTY(); }
 		SUBSTRATE_NO_DISCARD(constexpr bool valid() const noexcept) { return fd != -1; }
 		SUBSTRATE_NO_DISCARD(constexpr bool isTTY() const noexcept) { return _tty; }
-#if defined(_WIN32)
+#ifdef _WIN32
 		SUBSTRATE_NO_DISCARD(void *handle() const noexcept)
 			{ return reinterpret_cast<void *>(_get_osfhandle(fd)); }
 #endif

--- a/substrate/console
+++ b/substrate/console
@@ -66,6 +66,10 @@ namespace substrate
 		void write(const void *buffer, size_t bufferLen) const noexcept;
 		void write(const char *value) const noexcept;
 		void write(const char *value, size_t valueLen) const noexcept;
+#ifdef _WIN32
+		void write(const wchar_t *value) const noexcept;
+		void write(const wchar_t *value, size_t valueLen) const noexcept;
+#endif
 		void write(const char value) const noexcept { write(&value, 1U); }
 		template<typename T> enable_if_t<!std::is_array<T>::value>
 			write(const std::unique_ptr<T> &value) const noexcept
@@ -75,6 +79,10 @@ namespace substrate
 			{ write(value.get()); }
 		void write(const std::string &value) const noexcept
 			{ write(value.data(), value.length()); }
+#ifdef _WIN32
+		void write(const std::wstring &value) const noexcept
+			{ write(value.data(), value.length()); }
+#endif
 #if __cplusplus >= 201703L
 		void write(const std::string_view &value) const noexcept
 			{ write(value.data(), value.length()); }

--- a/test/socket.cxx
+++ b/test/socket.cxx
@@ -8,7 +8,7 @@
 #ifndef NOMINMAX
 #define NOMINMAX
 #endif
-#include <Winsock2.h>
+#include <winsock2.h>
 #endif
 #include <cstring>
 #include <substrate/socket>


### PR DESCRIPTION
This PR aims to improve how we handle strings in console_t/consoleStream_t on Windows and in general Unicode handling on output.

This fixes an issue where std::string's containing UTF-8 would not get converted on Windows, resulting in garbled output.

We also implement support for std::wstring/wchar_t and std::u16String/char16_t strings though the former is only for Windows. This should allow any UTF-16 or wide Windows character strings to be correctly displayed in a program's output just the same as any other strings.

Some of the architectural changes should also provide a nice speed boost for STL string containers by not throwing away the length information only to have to re-calculate it.