### PR TITLE
Feature: Improved command-line arguments parsing

### DIFF
--- a/impl/command_line/arguments.cxx
+++ b/impl/command_line/arguments.cxx
@@ -472,12 +472,10 @@ namespace substrate::commandLine
 	}
 
 	// Implementation of the innards of arguments_t as otherwise we get compile errors
-	// NOLINTNEXTLINE(modernize-use-equals-default)
-	arguments_t::arguments_t() noexcept : _arguments{} { }
-	arguments_t::arguments_t(const arguments_t &arguments) noexcept : _arguments{arguments._arguments} { }
-	arguments_t::arguments_t(arguments_t &&arguments) noexcept : _arguments{std::move(arguments._arguments)} { }
-	// NOLINTNEXTLINE(modernize-use-equals-default)
-	arguments_t::~arguments_t() noexcept { }
+	arguments_t::arguments_t() noexcept = default;
+	arguments_t::arguments_t(const arguments_t &arguments) noexcept = default;
+	arguments_t::arguments_t(arguments_t &&arguments) noexcept = default;
+	arguments_t::~arguments_t() noexcept = default;
 	size_t arguments_t::count() const noexcept
 		{ return _arguments.size(); }
 	size_t arguments_t::countMatching(const std::string_view &option) const noexcept
@@ -489,17 +487,9 @@ namespace substrate::commandLine
 	arguments_t::iterator_t arguments_t::find(const std::string_view &option) const noexcept
 		{ return _arguments.find(option); }
 
-	arguments_t &arguments_t::operator =(const arguments_t &arguments) noexcept
-	{
-		_arguments = arguments._arguments;
-		return *this;
-	}
+	arguments_t &arguments_t::operator =(const arguments_t &arguments) noexcept = default;
 
-	arguments_t &arguments_t::operator =(arguments_t &&arguments) noexcept
-	{
-		_arguments = std::move(arguments._arguments);
-		return *this;
-	}
+	arguments_t &arguments_t::operator =(arguments_t &&arguments) noexcept = default;
 
 	// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 	std::vector<const item_t *> arguments_t::findAll(const std::string_view &option) const noexcept

--- a/impl/command_line/arguments.cxx
+++ b/impl/command_line/arguments.cxx
@@ -476,6 +476,8 @@ namespace substrate::commandLine
 	arguments_t::arguments_t(const arguments_t &arguments) noexcept = default;
 	arguments_t::arguments_t(arguments_t &&arguments) noexcept = default;
 	arguments_t::~arguments_t() noexcept = default;
+	arguments_t &arguments_t::operator =(const arguments_t &arguments) noexcept = default;
+	arguments_t &arguments_t::operator =(arguments_t &&arguments) noexcept = default;
 	size_t arguments_t::count() const noexcept
 		{ return _arguments.size(); }
 	size_t arguments_t::countMatching(const std::string_view &option) const noexcept
@@ -486,10 +488,6 @@ namespace substrate::commandLine
 		{ return _arguments.end(); }
 	arguments_t::iterator_t arguments_t::find(const std::string_view &option) const noexcept
 		{ return _arguments.find(option); }
-
-	arguments_t &arguments_t::operator =(const arguments_t &arguments) noexcept = default;
-
-	arguments_t &arguments_t::operator =(arguments_t &&arguments) noexcept = default;
 
 	// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 	std::vector<const item_t *> arguments_t::findAll(const std::string_view &option) const noexcept

--- a/impl/command_line/arguments.cxx
+++ b/impl/command_line/arguments.cxx
@@ -473,10 +473,10 @@ namespace substrate::commandLine
 
 	// Implementation of the innards of arguments_t as otherwise we get compile errors
 	arguments_t::arguments_t() noexcept = default;
-	arguments_t::arguments_t(const arguments_t &arguments) noexcept = default;
+	arguments_t::arguments_t(const arguments_t &arguments) = default;
 	arguments_t::arguments_t(arguments_t &&arguments) noexcept = default;
 	arguments_t::~arguments_t() noexcept = default;
-	arguments_t &arguments_t::operator =(const arguments_t &arguments) noexcept = default;
+	arguments_t &arguments_t::operator =(const arguments_t &arguments) = default;
 	arguments_t &arguments_t::operator =(arguments_t &&arguments) noexcept = default;
 	size_t arguments_t::count() const noexcept
 		{ return _arguments.size(); }

--- a/impl/command_line/arguments.cxx
+++ b/impl/command_line/arguments.cxx
@@ -363,18 +363,23 @@ namespace substrate::commandLine
 		// Clone the existing set of global options
 		auto result{globalOptions};
 		// Loop through the current level's options and pull out any that are global
-		for (const auto &option : options)
-		{
-			std::visit(match_t
+		std::for_each
+		(
+			options.begin(),
+			options.end(),
+			[&](const internal::optionsItem_t &option)
 			{
-				[&](const option_t &value)
+				std::visit(match_t
 				{
-					if (value.isGlobal())
-						result.insert(value);
-				},
-				[&](const optionSet_t &) { },
-			}, option);
-		}
+					[&](const option_t &value)
+					{
+						if (value.isGlobal())
+							result.insert(value);
+					},
+					[&](const optionSet_t &) { },
+				}, option);
+			}
+		);
 		// Having gathered all of them up, return the new set
 		return result;
 	}

--- a/impl/command_line/arguments.cxx
+++ b/impl/command_line/arguments.cxx
@@ -8,6 +8,7 @@
 
 using namespace std::literals::string_literals;
 using namespace std::literals::string_view_literals;
+using optionsVisited_t = substrate::commandLine::arguments_t::optionsVisited_t;
 
 namespace substrate::commandLine
 {
@@ -129,7 +130,7 @@ namespace substrate::commandLine
 	[[nodiscard]] static auto collectRequiredOptions(const options_t &options) noexcept
 	{
 		// Build a set of all the required options defined in this options_t
-		std::set<internal::optionsItem_t> requiredOptions{};
+		optionsVisited_t requiredOptions{};
 		for (const auto &option : options)
 		{
 			// If the optionItem_t is a bad variant, ignore it
@@ -161,7 +162,7 @@ namespace substrate::commandLine
 		}, item);
 	}
 
-	[[nodiscard]] static size_t checkExclusivity(const std::set<internal::optionsItem_t> &options) noexcept
+	[[nodiscard]] static size_t checkExclusivity(const optionsVisited_t &options) noexcept
 	{
 		std::set<option_t> exclusiveOptions{};
 		// Loop through all the visited options
@@ -191,6 +192,7 @@ namespace substrate::commandLine
 	}
 
 	// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+	// NOLINTNEXTLINE(performance-unnecessary-value-param)
 	bool arguments_t::parseFrom(tokeniser_t &lexer, const options_t &options, const optionsVisited_t globalOptions)
 	{
 		const auto &token{lexer.token()};
@@ -238,7 +240,7 @@ namespace substrate::commandLine
 		const std::string_view &argument) noexcept;
 	static std::optional<optionMatch_t> matchOptionSet(tokeniser_t &lexer, const optionSet_t &option,
 		const std::string_view &argument, const options_t &options,
-		const std::set<internal::optionsItem_t> &globalOptions) noexcept;
+		const optionsVisited_t &globalOptions) noexcept;
 	template<typename set_t> static bool checkMatchValid(const optionsItem_t &option, set_t &optionsVisited) noexcept;
 	template<typename set_t> static std::optional<bool> handleResult(arguments_t &arguments, const optionsItem_t &option,
 		set_t &optionsVisited, const std::string_view &argument, const optionMatch_t &match) noexcept;
@@ -361,8 +363,8 @@ namespace substrate::commandLine
 		return flag_t{option.metaName(), std::move(*value)};
 	}
 
-	static std::set<internal::optionsItem_t> gatherGlobals(const options_t &options,
-		const std::set<internal::optionsItem_t> &globalOptions) noexcept
+	static auto gatherGlobals(const options_t &options,
+		const optionsVisited_t &globalOptions) noexcept
 	{
 		// Clone the existing set of global options
 		auto result{globalOptions};
@@ -390,7 +392,7 @@ namespace substrate::commandLine
 
 	static std::optional<optionMatch_t> matchOptionSet(tokeniser_t &lexer, const optionSet_t &option,
 		const std::string_view &argument, const options_t &options,
-		const std::set<internal::optionsItem_t> &globalOptions) noexcept
+		const optionsVisited_t &globalOptions) noexcept
 	{
 		// Check if we're parsing an alternation from a set
 		const auto match{option.matches(argument)};

--- a/impl/command_line/options.cxx
+++ b/impl/command_line/options.cxx
@@ -6,6 +6,7 @@
 #include <substrate/console>
 #include <substrate/conversions>
 #include <substrate/index_sequence>
+#include <substrate/utility>
 
 using namespace std::literals::string_literals;
 using namespace std::literals::string_view_literals;
@@ -201,6 +202,7 @@ namespace substrate::commandLine
 			case optionValueType_t::userDefined:
 				return "VAL"sv;
 		}
+		substrate::unreachable();
 	}
 
 	[[nodiscard]] std::string option_t::displayName() const noexcept
@@ -220,9 +222,7 @@ namespace substrate::commandLine
 		{
 			[&](const std::string_view &option) { return std::string{option} + typeValue; },
 			[&](const optionFlagPair_t &option)
-			{	
-				return std::string{option._shortFlag} + ", "s + std::string{option._longFlag} + typeValue;
-			},
+				{ return std::string{option._shortFlag} + ", "s + std::string{option._longFlag} + typeValue; },
 			[&](const optionValue_t &option) { return std::string{option.metaName()} + (isRepeatable() ? "..."s : ""s); }
 		}, _option);
 	}

--- a/substrate/command_line/arguments
+++ b/substrate/command_line/arguments
@@ -40,10 +40,12 @@ namespace substrate::commandLine
 
 	struct SUBSTRATE_CLS_API arguments_t
 	{
+	public:
+		using optionsVisited_t = std::set<internal::optionsItem_t>;
+
 	private:
 		using storage_t = std::multiset<item_t, std::less<void>>;
 		using iterator_t = typename storage_t::const_iterator;
-		using optionsVisited_t = std::set<internal::optionsItem_t>;
 
 		storage_t _arguments;
 

--- a/substrate/command_line/arguments
+++ b/substrate/command_line/arguments
@@ -47,7 +47,7 @@ namespace substrate::commandLine
 		using storage_t = std::multiset<item_t, std::less<void>>;
 		using iterator_t = typename storage_t::const_iterator;
 
-		storage_t _arguments;
+		storage_t _arguments{};
 
 		[[nodiscard]] std::optional<bool> parseArgument(internal::tokeniser_t &lexer, const options_t &options,
 			const optionsVisited_t &globalOptions, optionsVisited_t &optionsVisited) noexcept;

--- a/substrate/command_line/arguments
+++ b/substrate/command_line/arguments
@@ -48,7 +48,7 @@ namespace substrate::commandLine
 		storage_t _arguments;
 
 		[[nodiscard]] std::optional<bool> parseArgument(internal::tokeniser_t &lexer, const options_t &options,
-			optionsVisited_t &optionsVisited) noexcept;
+			const optionsVisited_t &globalOptions, optionsVisited_t &optionsVisited) noexcept;
 
 	public:
 		arguments_t() noexcept;
@@ -58,7 +58,8 @@ namespace substrate::commandLine
 		arguments_t &operator =(const arguments_t &arguments) noexcept;
 		arguments_t &operator =(arguments_t &&arguments) noexcept;
 
-		[[nodiscard]] bool parseFrom(internal::tokeniser_t &lexer, const options_t &options);
+		[[nodiscard]] bool parseFrom(internal::tokeniser_t &lexer, const options_t &options,
+			optionsVisited_t globalOptions);
 		[[nodiscard]] bool add(item_t argument) noexcept;
 
 		[[nodiscard]] size_t count() const noexcept;

--- a/substrate/command_line/arguments
+++ b/substrate/command_line/arguments
@@ -54,10 +54,10 @@ namespace substrate::commandLine
 
 	public:
 		arguments_t() noexcept;
-		arguments_t(const arguments_t &arguments) noexcept;
+		arguments_t(const arguments_t &arguments);
 		arguments_t(arguments_t &&arguments) noexcept;
 		~arguments_t() noexcept;
-		arguments_t &operator =(const arguments_t &arguments) noexcept;
+		arguments_t &operator =(const arguments_t &arguments);
 		arguments_t &operator =(arguments_t &&arguments) noexcept;
 
 		[[nodiscard]] bool parseFrom(internal::tokeniser_t &lexer, const options_t &options,

--- a/substrate/command_line/options
+++ b/substrate/command_line/options
@@ -25,6 +25,8 @@ namespace substrate::commandLine
 		repeatable,
 		takesParameter,
 		required,
+		global,
+		exclusive,
 	};
 
 	enum class optionValueType_t
@@ -125,6 +127,18 @@ namespace substrate::commandLine
 			return *this;
 		}
 
+		[[nodiscard]] constexpr option_t &global() noexcept
+		{
+			_flags.set(optionFlags_t::global);
+			return *this;
+		}
+
+		[[nodiscard]] constexpr option_t &exclusive() noexcept
+		{
+			_flags.set(optionFlags_t::exclusive);
+			return *this;
+		}
+
 		template<typename T> [[nodiscard]] constexpr option_t &valueRange(T min, T max) noexcept
 		{
 			// These perform casts only to silence conversion warnings
@@ -144,6 +158,10 @@ namespace substrate::commandLine
 			{ return _flags.includes(optionFlags_t::repeatable); }
 		[[nodiscard]] constexpr bool isRequired() const noexcept
 			{ return _flags.includes(optionFlags_t::required); }
+		[[nodiscard]] constexpr bool isGlobal() const noexcept
+			{ return _flags.includes(optionFlags_t::global); }
+		[[nodiscard]] constexpr bool isExclusive() const noexcept
+			{ return _flags.includes(optionFlags_t::exclusive); }
 		[[nodiscard]] constexpr bool valueOnly() const noexcept
 			{ return std::holds_alternative<optionValue_t>(_option); }
 


### PR DESCRIPTION
In this PR we seek to improve the state of the command line arguments parser by implementing two new features that solve usability problems and bring us closer to parity with Rust's Clap and Python's argparse.

The first of these new features is option exclusivity, whereby you can define multiple options at a parsing level to be exclusive of one another and bypass requirements checks for normal options - this is done with the new options_t helper `.exclusive()` and allows, eg, `--version` and `--help` to be defined and made exclusive of each other + uncaring of other arguments requirements validity.

The second of these features is option globalness, whereby an option can be defined to be "global" (visible to its level and all parsing levels below that) such as a `--help` option that should appear on every level of parsing (through optionSet_t barriers) to improve the usage of the parser.